### PR TITLE
Limit the parallelism of the concurrent get benchmark

### DIFF
--- a/cache_test.go
+++ b/cache_test.go
@@ -646,10 +646,20 @@ func BenchmarkCacheGetConcurrent(b *testing.B) {
 	tc := New(0, 0)
 	tc.Set("foo", "bar", 0)
 	wg := new(sync.WaitGroup)
-	wg.Add(b.N)
-	for i := 0; i < b.N; i++ {
+	children := b.N
+	iterations := 1
+
+	if children > 10000 {
+		children = 10000
+		iterations = b.N / children
+	}
+
+	wg.Add(children)
+	for i := 0; i < children; i++ {
 		go func() {
-			tc.Get("foo")
+			for j := 0; j < iterations; j++ {
+				tc.Get("foo")
+			}
 			wg.Done()
 		}()
 	}


### PR DESCRIPTION
This was killing my machine.  This change lets me actually run it.  :)

```
BenchmarkCacheGetConcurrent 20000000            83.5 ns/op
BenchmarkCacheGetConcurrent-2    5000000           405 ns/op
BenchmarkCacheGetConcurrent-4    5000000           311 ns/op
BenchmarkCacheGetConcurrent-8    5000000           363 ns/op
```
