### PR TITLE
Make Save/Load thread-safe

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -5,3 +5,4 @@ code was contributed.)
 
 Dustin Sallings <dustin@spy.net>
 Sergey Shepelev <temotor@gmail.com>
+Alan Shreve <alan@inconshreveable.com>


### PR DESCRIPTION
Before adding code to my project that called Save/Load, I noticed that they weren't using the cache lock to be thread-safe. I've made them threadsafe with locks, and the Save() operation copies out the cache items to a temporary map first so that the lock is never held when doing I/O.
