### PR TITLE
Fix unprotected access to shared state in Save()

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -5,3 +5,4 @@ code was contributed.)
 
 Dustin Sallings <dustin@spy.net>
 Sergey Shepelev <temotor@gmail.com>
+Alan Shreve <alan@inconshreveable.com>

--- a/cache.go
+++ b/cache.go
@@ -876,9 +876,10 @@ func (c *cache) Save(w io.Writer) (err error) {
 		}
 	}()
 	c.RLock()
-	items := c.items
-	for _, v := range items {
+	items := make(map[string]*item, len(c.items))
+	for k, v := range c.items {
 		gob.Register(v.Object)
+		items[k] = v
 	}
 	c.RUnlock()
 	err = enc.Encode(&items)


### PR DESCRIPTION
This fixes an issue in save where the map was not safely copied. This led to a unprotected access of shared state and a thus a possible race condition while writing the cached items to the output stream. The original code copied the map with an assignment statement which does not copy the map data structure, just a new pointer to the same map.
