### PR TITLE
An Unobtrusive LRU for the best time cache I've used for go

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2012-2016 Patrick Mylund Nielsen and the go-cache contributors
+Copyright (c) 2012-2017 Patrick Mylund Nielsen and the go-cache contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2012-2015 Patrick Mylund Nielsen and the go-cache contributors
+Copyright (c) 2012-2016 Patrick Mylund Nielsen and the go-cache contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -20,86 +20,85 @@ one) to recover from downtime quickly. (See the docs for `NewFrom()` for caveats
 ### Usage
 
 ```go
-	import (
-		"fmt"
-		"github.com/patrickmn/go-cache"
-		"time"
-	)
+import (
+	"fmt"
+	"github.com/patrickmn/go-cache"
+	"time"
+)
 
-	func main() {
+func main() {
+	// Create a cache with a default expiration time of 5 minutes, and which
+	// purges expired items every 10 minutes
+	c := cache.New(5*time.Minute, 10*time.Minute)
 
-		// Create a cache with a default expiration time of 5 minutes, and which
-		// purges expired items every 30 seconds
-		c := cache.New(5*time.Minute, 30*time.Second)
+	// Set the value of the key "foo" to "bar", with the default expiration time
+	c.Set("foo", "bar", cache.DefaultExpiration)
 
-		// Set the value of the key "foo" to "bar", with the default expiration time
-		c.Set("foo", "bar", cache.DefaultExpiration)
+	// Set the value of the key "baz" to 42, with no expiration time
+	// (the item won't be removed until it is re-set, or removed using
+	// c.Delete("baz")
+	c.Set("baz", 42, cache.NoExpiration)
 
-		// Set the value of the key "baz" to 42, with no expiration time
-		// (the item won't be removed until it is re-set, or removed using
-		// c.Delete("baz")
-		c.Set("baz", 42, cache.NoExpiration)
-
-		// Get the string associated with the key "foo" from the cache
-		foo, found := c.Get("foo")
-		if found {
-			fmt.Println(foo)
-		}
-
-		// Since Go is statically typed, and cache values can be anything, type
-		// assertion is needed when values are being passed to functions that don't
-		// take arbitrary types, (i.e. interface{}). The simplest way to do this for
-		// values which will only be used once--e.g. for passing to another
-		// function--is:
-		foo, found := c.Get("foo")
-		if found {
-			MyFunction(foo.(string))
-		}
-
-		// This gets tedious if the value is used several times in the same function.
-		// You might do either of the following instead:
-		if x, found := c.Get("foo"); found {
-			foo := x.(string)
-			// ...
-		}
-		// or
-		var foo string
-		if x, found := c.Get("foo"); found {
-			foo = x.(string)
-		}
-		// ...
-		// foo can then be passed around freely as a string
-
-		// Want performance? Store pointers!
-		c.Set("foo", &MyStruct, cache.DefaultExpiration)
-		if x, found := c.Get("foo"); found {
-			foo := x.(*MyStruct)
-			// ...
-		}
-
-		// If you store a reference type like a pointer, slice, map or channel, you
-		// do not need to run Set if you modify the underlying data. The cached
-		// reference points to the same memory, so if you modify a struct whose
-		// pointer you've stored in the cache, retrieving that pointer with Get will
-		// point you to the same data:
-		foo := &MyStruct{Num: 1}
-		c.Set("foo", foo, cache.DefaultExpiration)
-		// ...
-		x, _ := c.Get("foo")
-		foo := x.(*MyStruct)
-		fmt.Println(foo.Num)
-		// ...
-		foo.Num++
-		// ...
-		x, _ := c.Get("foo")
-		foo := x.(*MyStruct)
-		foo.Println(foo.Num)
-
-		// will print:
-		// 1
-		// 2
-
+	// Get the string associated with the key "foo" from the cache
+	foo, found := c.Get("foo")
+	if found {
+		fmt.Println(foo)
 	}
+
+	// Since Go is statically typed, and cache values can be anything, type
+	// assertion is needed when values are being passed to functions that don't
+	// take arbitrary types, (i.e. interface{}). The simplest way to do this for
+	// values which will only be used once--e.g. for passing to another
+	// function--is:
+	foo, found := c.Get("foo")
+	if found {
+		MyFunction(foo.(string))
+	}
+
+	// This gets tedious if the value is used several times in the same function.
+	// You might do either of the following instead:
+	if x, found := c.Get("foo"); found {
+		foo := x.(string)
+		// ...
+	}
+	// or
+	var foo string
+	if x, found := c.Get("foo"); found {
+		foo = x.(string)
+	}
+	// ...
+	// foo can then be passed around freely as a string
+
+	// Want performance? Store pointers!
+	c.Set("foo", &MyStruct, cache.DefaultExpiration)
+	if x, found := c.Get("foo"); found {
+		foo := x.(*MyStruct)
+			// ...
+	}
+
+	// If you store a reference type like a pointer, slice, map or channel, you
+	// do not need to run Set if you modify the underlying data. The cached
+	// reference points to the same memory, so if you modify a struct whose
+	// pointer you've stored in the cache, retrieving that pointer with Get will
+	// point you to the same data:
+	foo := &MyStruct{Num: 1}
+	c.Set("foo", foo, cache.DefaultExpiration)
+	// ...
+	x, _ := c.Get("foo")
+	foo := x.(*MyStruct)
+	fmt.Println(foo.Num)
+	// ...
+	foo.Num++
+	// ...
+	x, _ := c.Get("foo")
+	foo := x.(*MyStruct)
+	foo.Println(foo.Num)
+
+	// will print:
+	// 1
+	// 2
+
+}
 ```
 
 ### Reference

--- a/README.md
+++ b/README.md
@@ -75,29 +75,6 @@ func main() {
 		foo := x.(*MyStruct)
 			// ...
 	}
-
-	// If you store a reference type like a pointer, slice, map or channel, you
-	// do not need to run Set if you modify the underlying data. The cached
-	// reference points to the same memory, so if you modify a struct whose
-	// pointer you've stored in the cache, retrieving that pointer with Get will
-	// point you to the same data:
-	foo := &MyStruct{Num: 1}
-	c.Set("foo", foo, cache.DefaultExpiration)
-	// ...
-	x, _ := c.Get("foo")
-	foo := x.(*MyStruct)
-	fmt.Println(foo.Num)
-	// ...
-	foo.Num++
-	// ...
-	x, _ := c.Get("foo")
-	foo := x.(*MyStruct)
-	foo.Println(foo.Num)
-
-	// will print:
-	// 1
-	// 2
-
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ cache can be saved to and loaded from a file (using `c.Items()` to retrieve the
 items map to serialize, and `NewFrom()` to create a cache from a deserialized
 one) to recover from downtime quickly. (See the docs for `NewFrom()` for caveats.)
 
-When creating a cache object using `NewWithLRU()`, if you set the maxItems value 
-above 0, the LRU functionality is enabled. The cache automatically updates a 
-timestamp every time a given item is retrieved. In the background, the janitor takes 
-care of deleting items that have expired because of staleness, or are 
-least-recently-used when the cache is under pressure. Whatever you set your purge 
+When creating a cache object using `NewWithLRU()`, if you set the maxItems value
+above 0, the LRU functionality is enabled. The cache automatically updates a
+timestamp every time a given item is retrieved. In the background, the janitor takes
+care of deleting items that have expired because of staleness, or are
+least-recently-used when the cache is under pressure. Whatever you set your purge
 interval to controls when the item will actually be removed from the cache. If you
-don't want to use the janitor, and wish to manually purge LRU items, then 
+don't want to use the janitor, and wish to manually purge LRU items, then
 `c.DeleteLRU(n)` where `n` is the number of items you'd like to purge.
 
 ### Installation

--- a/cache.go
+++ b/cache.go
@@ -81,6 +81,12 @@ func (c *cache) set(k string, x interface{}, d time.Duration) {
 	}
 }
 
+// Add an item to the cache, replacing any existing item, using the default
+// expiration.
+func (c *cache) SetDefault(k string, x interface{}) {
+	c.Set(k, x, DefaultExpiration)
+}
+
 // Add an item to the cache only if an item doesn't already exist for the given
 // key, or if the existing item has expired. Returns an error otherwise.
 func (c *cache) Add(k string, x interface{}, d time.Duration) error {

--- a/cache.go
+++ b/cache.go
@@ -25,9 +25,8 @@ func (item Item) Expired() bool {
 }
 
 // Return the time at which this item was last accessed.
-func (item Item) LastAccessed() *time.Time {
-	t := time.Unix(0, item.Accessed)
-	return &t
+func (item Item) LastAccessed() time.Time {
+	return time.Unix(0, item.Accessed)
 }
 
 const (

--- a/cache.go
+++ b/cache.go
@@ -1005,6 +1005,7 @@ func (c *cache) Items() map[string]Item {
 	m := make(map[string]Item, len(c.items))
 	now := time.Now().UnixNano()
 	for k, v := range c.items {
+		// "Inlining" of Expired
 		if v.Expiration > 0 {
 			if now > v.Expiration {
 				continue

--- a/cache.go
+++ b/cache.go
@@ -177,8 +177,10 @@ func (c *cache) Get(k string) (interface{}, bool) {
 		}
 		return nil, false
 	}
+	var now int64
 	if item.Expiration > 0 {
-		if time.Now().UnixNano() > item.Expiration {
+		now = time.Now().UnixNano()
+		if now > item.Expiration {
 			if c.maxItems > 0 {
 				c.mu.Unlock()
 			} else {
@@ -188,7 +190,10 @@ func (c *cache) Get(k string) (interface{}, bool) {
 		}
 	}
 	if c.maxItems > 0 {
-		item.Accessed = time.Now().UnixNano()
+		if now == 0 {
+			now = time.Now().UnixNano()
+		}
+		item.Accessed = now
 		c.items[k] = item
 		c.mu.Unlock()
 	} else {
@@ -205,13 +210,18 @@ func (c *cache) get(k string) (interface{}, bool) {
 		return nil, false
 	}
 	// "Inlining" of Expired
+	var now int64
 	if item.Expiration > 0 {
-		if time.Now().UnixNano() > item.Expiration {
+		now = time.Now().UnixNano()
+		if now > item.Expiration {
 			return nil, false
 		}
 	}
 	if c.maxItems > 0 {
-		item.Accessed = time.Now().UnixNano()
+		if now == 0 {
+			now = time.Now().UnixNano()
+		}
+		item.Accessed = now
 		c.items[k] = item
 	}
 	return item.Object, true
@@ -239,8 +249,10 @@ func (c *cache) GetWithExpiration(k string) (interface{}, time.Time, bool) {
 		}
 		return nil, time.Time{}, false
 	}
+	var now int64
 	if item.Expiration > 0 {
-		if time.Now().UnixNano() > item.Expiration {
+		now = time.Now().UnixNano()
+		if now > item.Expiration {
 			if c.maxItems > 0 {
 				c.mu.Unlock()
 			} else {
@@ -249,7 +261,10 @@ func (c *cache) GetWithExpiration(k string) (interface{}, time.Time, bool) {
 			return nil, time.Time{}, false
 		}
 		if c.maxItems > 0 {
-			item.Accessed = time.Now().UnixNano()
+			if now == 0 {
+				now = time.Now().UnixNano()
+			}
+			item.Accessed = now
 			c.items[k] = item
 			c.mu.Unlock()
 		} else {
@@ -258,7 +273,10 @@ func (c *cache) GetWithExpiration(k string) (interface{}, time.Time, bool) {
 		return item.Object, time.Unix(0, item.Expiration), true
 	}
 	if c.maxItems > 0 {
-		item.Accessed = time.Now().UnixNano()
+		if now == 0 {
+			now = time.Now().UnixNano()
+		}
+		item.Accessed = now
 		c.items[k] = item
 		c.mu.Unlock()
 	} else {


### PR DESCRIPTION
I needed a time AND LRU cache. By far, this is the best time cache I've found for go. As such, I've injected LRU capabilities that simply:
- ensures that when an item is added, if the number of unexpired items >= maximum number of items specified, the oldest (based on ACCESS) is expired
- when an item is "gotten", or "set", the access time is updated

The existing janitor system is unchanged, and used to actually delete the items.

The only change from a consumer standpoint, is one additional parameter at the end of a "New" call, that specifies the maximum number of items to allow, or 0, if you want to disable the LRU completely.

I updated the "test" file so that it would run as-is with LRU disabled. I used my own test harness that isn't horribly portable. I'll work on updating yours with LRU tests in my Copious Free Time (patent pending) if you're interested in accepting this pull.

This is 1/2 of what #5 is asking for.
