### PR TITLE
Added BST for efficient deletion

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2012-2014 Patrick Mylund Nielsen and the go-cache contributors
+Copyright (c) 2012-2015 Patrick Mylund Nielsen and the go-cache contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/cache.go
+++ b/cache.go
@@ -13,13 +13,13 @@ import (
 
 
 type Item struct {
-	Object     	interface{}
-	Expiration 	int64
+	Object     interface{}
+	Expiration int64
 }
 
 type Node struct {
-	Expiration 	int64
-	Key 		   	string
+	Expiration int64
+	Key        string
 }
 
 func (node Node) Less(than llrb.Item) bool {
@@ -50,12 +50,12 @@ type Cache struct {
 }
 
 type cache struct {
-	defaultExpiration 	time.Duration
-	items           		map[string]Item
-	mu              		sync.RWMutex
-	onEvicted       		func(string, interface{})
-	janitor      		*janitor
-	sortedItems			*llrb.LLRB
+	defaultExpiration time.Duration
+	items             map[string]Item
+	mu                sync.RWMutex
+	onEvicted         func(string, interface{})
+	janitor           *janitor
+	sortedItems       *llrb.LLRB
 }
 
 // Add an item to the cache, replacing any existing item. If the duration is 0

--- a/cache.go
+++ b/cache.go
@@ -853,8 +853,8 @@ func (c *cache) DeleteExpired() {
 }
 
 // Sets an (optional) function that is called with the key and value when an
-// item is evicted from the cache. (Including when it is deleted manually.)
-// Set to nil to disable.
+// item is evicted from the cache. (Including when it is deleted manually, but
+// not when it is overwritten.) Set to nil to disable.
 func (c *cache) OnEvicted(f func(string, interface{})) {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/cache.go
+++ b/cache.go
@@ -10,14 +10,16 @@ import (
 	"time"
 )
 
+var emptyTime = time.Time{}
+
 type Item struct {
 	Object     interface{}
-	Expiration *time.Time
+	Expiration time.Time
 }
 
 // Returns true if the item has expired.
-func (item *Item) Expired() bool {
-	if item.Expiration == nil {
+func (item Item) Expired() bool {
+	if item.Expiration == emptyTime {
 		return false
 	}
 	return item.Expiration.Before(time.Now())
@@ -39,7 +41,7 @@ type Cache struct {
 
 type cache struct {
 	defaultExpiration time.Duration
-	items             map[string]*Item
+	items             map[string]Item
 	mu                sync.RWMutex
 	onEvicted         func(string, interface{})
 	janitor           *janitor
@@ -57,15 +59,14 @@ func (c *cache) Set(k string, x interface{}, d time.Duration) {
 }
 
 func (c *cache) set(k string, x interface{}, d time.Duration) {
-	var e *time.Time
+	e := emptyTime
 	if d == DefaultExpiration {
 		d = c.defaultExpiration
 	}
 	if d > 0 {
-		t := time.Now().Add(d)
-		e = &t
+		e = time.Now().Add(d)
 	}
-	c.items[k] = &Item{
+	c.items[k] = Item{
 		Object:     x,
 		Expiration: e,
 	}
@@ -159,6 +160,7 @@ func (c *cache) Increment(k string, n int64) error {
 		c.mu.Unlock()
 		return fmt.Errorf("The value for %s is not an integer", k)
 	}
+	c.items[k] = v
 	c.mu.Unlock()
 	return nil
 }
@@ -184,6 +186,7 @@ func (c *cache) IncrementFloat(k string, n float64) error {
 		c.mu.Unlock()
 		return fmt.Errorf("The value for %s does not have type float32 or float64", k)
 	}
+	c.items[k] = v
 	c.mu.Unlock()
 	return nil
 }
@@ -205,6 +208,7 @@ func (c *cache) IncrementInt(k string, n int) (int, error) {
 	}
 	nv := rv + n
 	v.Object = nv
+	c.items[k] = v
 	c.mu.Unlock()
 	return nv, nil
 }
@@ -226,6 +230,7 @@ func (c *cache) IncrementInt8(k string, n int8) (int8, error) {
 	}
 	nv := rv + n
 	v.Object = nv
+	c.items[k] = v
 	c.mu.Unlock()
 	return nv, nil
 }
@@ -247,6 +252,7 @@ func (c *cache) IncrementInt16(k string, n int16) (int16, error) {
 	}
 	nv := rv + n
 	v.Object = nv
+	c.items[k] = v
 	c.mu.Unlock()
 	return nv, nil
 }
@@ -268,6 +274,7 @@ func (c *cache) IncrementInt32(k string, n int32) (int32, error) {
 	}
 	nv := rv + n
 	v.Object = nv
+	c.items[k] = v
 	c.mu.Unlock()
 	return nv, nil
 }
@@ -289,6 +296,7 @@ func (c *cache) IncrementInt64(k string, n int64) (int64, error) {
 	}
 	nv := rv + n
 	v.Object = nv
+	c.items[k] = v
 	c.mu.Unlock()
 	return nv, nil
 }
@@ -310,6 +318,7 @@ func (c *cache) IncrementUint(k string, n uint) (uint, error) {
 	}
 	nv := rv + n
 	v.Object = nv
+	c.items[k] = v
 	c.mu.Unlock()
 	return nv, nil
 }
@@ -331,6 +340,7 @@ func (c *cache) IncrementUintptr(k string, n uintptr) (uintptr, error) {
 	}
 	nv := rv + n
 	v.Object = nv
+	c.items[k] = v
 	c.mu.Unlock()
 	return nv, nil
 }
@@ -352,6 +362,7 @@ func (c *cache) IncrementUint8(k string, n uint8) (uint8, error) {
 	}
 	nv := rv + n
 	v.Object = nv
+	c.items[k] = v
 	c.mu.Unlock()
 	return nv, nil
 }
@@ -373,6 +384,7 @@ func (c *cache) IncrementUint16(k string, n uint16) (uint16, error) {
 	}
 	nv := rv + n
 	v.Object = nv
+	c.items[k] = v
 	c.mu.Unlock()
 	return nv, nil
 }
@@ -394,6 +406,7 @@ func (c *cache) IncrementUint32(k string, n uint32) (uint32, error) {
 	}
 	nv := rv + n
 	v.Object = nv
+	c.items[k] = v
 	c.mu.Unlock()
 	return nv, nil
 }
@@ -415,6 +428,7 @@ func (c *cache) IncrementUint64(k string, n uint64) (uint64, error) {
 	}
 	nv := rv + n
 	v.Object = nv
+	c.items[k] = v
 	c.mu.Unlock()
 	return nv, nil
 }
@@ -436,6 +450,7 @@ func (c *cache) IncrementFloat32(k string, n float32) (float32, error) {
 	}
 	nv := rv + n
 	v.Object = nv
+	c.items[k] = v
 	c.mu.Unlock()
 	return nv, nil
 }
@@ -457,6 +472,7 @@ func (c *cache) IncrementFloat64(k string, n float64) (float64, error) {
 	}
 	nv := rv + n
 	v.Object = nv
+	c.items[k] = v
 	c.mu.Unlock()
 	return nv, nil
 }
@@ -506,6 +522,7 @@ func (c *cache) Decrement(k string, n int64) error {
 		c.mu.Unlock()
 		return fmt.Errorf("The value for %s is not an integer", k)
 	}
+	c.items[k] = v
 	c.mu.Unlock()
 	return nil
 }
@@ -531,6 +548,7 @@ func (c *cache) DecrementFloat(k string, n float64) error {
 		c.mu.Unlock()
 		return fmt.Errorf("The value for %s does not have type float32 or float64", k)
 	}
+	c.items[k] = v
 	c.mu.Unlock()
 	return nil
 }
@@ -552,6 +570,7 @@ func (c *cache) DecrementInt(k string, n int) (int, error) {
 	}
 	nv := rv - n
 	v.Object = nv
+	c.items[k] = v
 	c.mu.Unlock()
 	return nv, nil
 }
@@ -573,6 +592,7 @@ func (c *cache) DecrementInt8(k string, n int8) (int8, error) {
 	}
 	nv := rv - n
 	v.Object = nv
+	c.items[k] = v
 	c.mu.Unlock()
 	return nv, nil
 }
@@ -594,6 +614,7 @@ func (c *cache) DecrementInt16(k string, n int16) (int16, error) {
 	}
 	nv := rv - n
 	v.Object = nv
+	c.items[k] = v
 	c.mu.Unlock()
 	return nv, nil
 }
@@ -615,6 +636,7 @@ func (c *cache) DecrementInt32(k string, n int32) (int32, error) {
 	}
 	nv := rv - n
 	v.Object = nv
+	c.items[k] = v
 	c.mu.Unlock()
 	return nv, nil
 }
@@ -636,6 +658,7 @@ func (c *cache) DecrementInt64(k string, n int64) (int64, error) {
 	}
 	nv := rv - n
 	v.Object = nv
+	c.items[k] = v
 	c.mu.Unlock()
 	return nv, nil
 }
@@ -657,6 +680,7 @@ func (c *cache) DecrementUint(k string, n uint) (uint, error) {
 	}
 	nv := rv - n
 	v.Object = nv
+	c.items[k] = v
 	c.mu.Unlock()
 	return nv, nil
 }
@@ -678,6 +702,7 @@ func (c *cache) DecrementUintptr(k string, n uintptr) (uintptr, error) {
 	}
 	nv := rv - n
 	v.Object = nv
+	c.items[k] = v
 	c.mu.Unlock()
 	return nv, nil
 }
@@ -699,6 +724,7 @@ func (c *cache) DecrementUint8(k string, n uint8) (uint8, error) {
 	}
 	nv := rv - n
 	v.Object = nv
+	c.items[k] = v
 	c.mu.Unlock()
 	return nv, nil
 }
@@ -720,6 +746,7 @@ func (c *cache) DecrementUint16(k string, n uint16) (uint16, error) {
 	}
 	nv := rv - n
 	v.Object = nv
+	c.items[k] = v
 	c.mu.Unlock()
 	return nv, nil
 }
@@ -741,6 +768,7 @@ func (c *cache) DecrementUint32(k string, n uint32) (uint32, error) {
 	}
 	nv := rv - n
 	v.Object = nv
+	c.items[k] = v
 	c.mu.Unlock()
 	return nv, nil
 }
@@ -762,6 +790,7 @@ func (c *cache) DecrementUint64(k string, n uint64) (uint64, error) {
 	}
 	nv := rv - n
 	v.Object = nv
+	c.items[k] = v
 	c.mu.Unlock()
 	return nv, nil
 }
@@ -783,6 +812,7 @@ func (c *cache) DecrementFloat32(k string, n float32) (float32, error) {
 	}
 	nv := rv - n
 	v.Object = nv
+	c.items[k] = v
 	c.mu.Unlock()
 	return nv, nil
 }
@@ -804,6 +834,7 @@ func (c *cache) DecrementFloat64(k string, n float64) (float64, error) {
 	}
 	nv := rv - n
 	v.Object = nv
+	c.items[k] = v
 	c.mu.Unlock()
 	return nv, nil
 }
@@ -906,7 +937,7 @@ func (c *cache) SaveFile(fname string) error {
 // documentation for NewFrom().)
 func (c *cache) Load(r io.Reader) error {
 	dec := gob.NewDecoder(r)
-	items := map[string]*Item{}
+	items := map[string]Item{}
 	err := dec.Decode(&items)
 	if err == nil {
 		c.mu.Lock()
@@ -944,7 +975,7 @@ func (c *cache) LoadFile(fname string) error {
 // fields of the items should be checked. Note that explicit synchronization
 // is needed to use a cache and its corresponding Items() return value at
 // the same time, as the map is shared.
-func (c *cache) Items() map[string]*Item {
+func (c *cache) Items() map[string]Item {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.items
@@ -962,7 +993,7 @@ func (c *cache) ItemCount() int {
 // Delete all items from the cache.
 func (c *cache) Flush() {
 	c.mu.Lock()
-	c.items = map[string]*Item{}
+	c.items = map[string]Item{}
 	c.mu.Unlock()
 }
 
@@ -997,7 +1028,7 @@ func runJanitor(c *cache, ci time.Duration) {
 	go j.Run(c)
 }
 
-func newCache(de time.Duration, m map[string]*Item) *cache {
+func newCache(de time.Duration, m map[string]Item) *cache {
 	if de == 0 {
 		de = -1
 	}
@@ -1008,7 +1039,7 @@ func newCache(de time.Duration, m map[string]*Item) *cache {
 	return c
 }
 
-func newCacheWithJanitor(de time.Duration, ci time.Duration, m map[string]*Item) *Cache {
+func newCacheWithJanitor(de time.Duration, ci time.Duration, m map[string]Item) *Cache {
 	c := newCache(de, m)
 	// This trick ensures that the janitor goroutine (which--granted it
 	// was enabled--is running DeleteExpired on c forever) does not keep
@@ -1029,7 +1060,7 @@ func newCacheWithJanitor(de time.Duration, ci time.Duration, m map[string]*Item)
 // manually. If the cleanup interval is less than one, expired items are not
 // deleted from the cache before calling c.DeleteExpired().
 func New(defaultExpiration, cleanupInterval time.Duration) *Cache {
-	items := make(map[string]*Item)
+	items := make(map[string]Item)
 	return newCacheWithJanitor(defaultExpiration, cleanupInterval, items)
 }
 
@@ -1042,7 +1073,7 @@ func New(defaultExpiration, cleanupInterval time.Duration) *Cache {
 // NewFrom() also accepts an items map which will serve as the underlying map
 // for the cache. This is useful for starting from a deserialized cache
 // (serialized using e.g. gob.Encode() on c.Items()), or passing in e.g.
-// make(map[string]*Item, 500) to improve startup performance when the cache
+// make(map[string]Item, 500) to improve startup performance when the cache
 // is expected to reach a certain minimum size.
 //
 // Only the cache's methods synchronize access to this map, so it is not
@@ -1054,6 +1085,6 @@ func New(defaultExpiration, cleanupInterval time.Duration) *Cache {
 // gob.Register() the individual types stored in the cache before encoding a
 // map retrieved with c.Items(), and to register those same types before
 // decoding a blob containing an items map.
-func NewFrom(defaultExpiration, cleanupInterval time.Duration, items map[string]*Item) *Cache {
+func NewFrom(defaultExpiration, cleanupInterval time.Duration, items map[string]Item) *Cache {
 	return newCacheWithJanitor(defaultExpiration, cleanupInterval, items)
 }

--- a/cache.go
+++ b/cache.go
@@ -103,7 +103,6 @@ func (c *cache) deleteFromBst (node Node) {
 	}
 }
 
-
 // Add an item to the cache only if an item doesn't already exist for the given
 // key, or if the existing item has expired. Returns an error otherwise.
 func (c *cache) Add(k string, x interface{}, d time.Duration) error {

--- a/cache.go
+++ b/cache.go
@@ -19,7 +19,6 @@ type Item struct {
 }
 
 func (item Item) Less(than llrb.Item) bool {
-	//return item.Expiration.Before(than.(Item).Expiration)
 	return item.Expiration < than.(Item).Expiration 
 }
 
@@ -76,10 +75,8 @@ func (c *cache) set(k string, x interface{}, d time.Duration) {
 	}
 	if d > 0 {
 		item.Expiration = time.Now().Add(d).UnixNano()
-		//if an item with the same key exists in the cache, remove it from the bst
-		old, found := c.items[k]
-		if found {
-			c.sortedItems.Delete(old)
+		_, found := c.items[k]	
+		if !found {
 			c.sortedItems.InsertNoReplace(item)
 		}		
 	} 	
@@ -162,9 +159,6 @@ func (c *cache) Increment(k string, n int64) error {
 		c.mu.Unlock()
 		return fmt.Errorf("Item %s not found", k)
 	}
-	if v.Expiration != 0 {
-		c.sortedItems.Delete(v)
-	}
 	switch v.Object.(type) {
 	case int:
 		v.Object = v.Object.(int) + int(n)
@@ -197,9 +191,6 @@ func (c *cache) Increment(k string, n int64) error {
 		return fmt.Errorf("The value for %s is not an integer", k)
 	}
 	c.items[k] = v
-	if v.Expiration != 0 {
-		c.sortedItems.InsertNoReplace(v)
-	}
 	c.mu.Unlock()
 	return nil
 }

--- a/cache.go
+++ b/cache.go
@@ -11,7 +11,6 @@ import (
 	"time"
 )
 
-
 type Item struct {
 	Object     interface{}
 	Expiration int64
@@ -25,7 +24,6 @@ type Node struct {
 func (node Node) Less(than llrb.Item) bool {
 	return node.Expiration < than.(Node).Expiration 
 }
-
 
 // Returns true if the item has expired.
 func (item Item) Expired() bool {
@@ -907,13 +905,10 @@ func (c *cache) delete(k string) (interface{}, bool) {
 		c.deleteFromBst(Node{Expiration: v.Expiration, Key: k})
 		if c.onEvicted != nil {
 			return v.Object, true
-		} else {
-			return nil, false
 		}
 	}
 	return nil, false
 }
-
 
 type keyAndValue struct {
 	key   string
@@ -947,8 +942,6 @@ func (c *cache) DeleteExpired() {
 		}
 	}	
 }
-
-
 
 // Sets an (optional) function that is called with the key and value when an
 // item is evicted from the cache. (Including when it is deleted manually, but
@@ -1015,10 +1008,8 @@ func (c *cache) Load(r io.Reader) error {
 				c.items[k] = v
 				if !found {
 					c.sortedItems.InsertNoReplace(Node{Expiration: v.Expiration, Key: k})
-				}
-				
-			}
-	
+				}				
+			}	
 		}
 	}
 	return err

--- a/cache_test.go
+++ b/cache_test.go
@@ -1650,6 +1650,17 @@ func BenchmarkDeleteExpiredLoop(b *testing.B) {
 
 func BenchmarkLargeCache(b *testing.B) {
 	b.StopTimer()
+	tc := New(100*time.Millisecond, 1*time.Millisecond)
+	b.StartTimer()
+	b.N = 1000000
+	for i := 0; i < b.N; i++ {
+		tc.Set(strconv.Itoa(i), "bar", DefaultExpiration)
+	}
+}
+
+/*
+func BenchmarkLargeCache(b *testing.B) {
+	b.StopTimer()
 	tc := New(time.Second, 10*time.Millisecond)
 	end := time.Now().Add(tc.defaultExpiration)
 	var i int
@@ -1657,11 +1668,11 @@ func BenchmarkLargeCache(b *testing.B) {
 		tc.Set(strconv.Itoa(i), "bar", DefaultExpiration)
 		i++
 	}
-	/*
+	
 	for i := 0; i < 1000000; i++ {
 		tc.Set(strconv.Itoa(i), "bar", DefaultExpiration)
 	}
-	*/
+	
 	tc.DeleteExpired()
 	b.Logf("Cache size: %d", tc.ItemCount())
 	b.StartTimer()
@@ -1669,3 +1680,4 @@ func BenchmarkLargeCache(b *testing.B) {
 		tc.Set(strconv.Itoa(i), "bar", DefaultExpiration)
 	}
 }
+*/

--- a/cache_test.go
+++ b/cache_test.go
@@ -1618,15 +1618,15 @@ func BenchmarkDeleteExpired(b *testing.B) {
 
 func BenchmarkLargeCache(b *testing.B) {
 	b.StopTimer()
-	tc := New(200 * time.Millisecond, 50 * time.Millisecond)
+	tc := New(100 * time.Millisecond, 1 * time.Millisecond)
 	//tc.mu.Lock()
-	for i := 0; i < 100000; i++ {
-		tc.set(strconv.Itoa(i), "bar", DefaultExpiration)
+	for i := 0; i < 1000000; i++ {
+		tc.Set(strconv.Itoa(i), "bar", DefaultExpiration)
 	}
 	//tc.mu.Unlock()
 	tc.DeleteExpired()
 	b.StartTimer()
-	for i := 100000; i <100000 + b.N; i++ {
-		tc.set(strconv.Itoa(i), "bar", DefaultExpiration)
+	for i := 1000000; i <1000000 + b.N; i++ {
+		tc.Set(strconv.Itoa(i), "bar", DefaultExpiration)
 	}
 }

--- a/cache_test.go
+++ b/cache_test.go
@@ -1592,6 +1592,16 @@ func BenchmarkRWMutexMapSetDeleteSingleLock(b *testing.B) {
 	}
 }
 
+func BenchmarkIncrementInt(b *testing.B) {
+	b.StopTimer()
+	tc := New(DefaultExpiration, 0)
+	tc.Set("foo", 0, DefaultExpiration)
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		tc.IncrementInt("foo", 1)
+	}
+}
+
 func BenchmarkDeleteExpired(b *testing.B) {
 	b.StopTimer()
 	tc := New(1, 0)

--- a/cache_test.go
+++ b/cache_test.go
@@ -1591,3 +1591,19 @@ func BenchmarkRWMutexMapSetDeleteSingleLock(b *testing.B) {
 		mu.Unlock()
 	}
 }
+
+func BenchmarkDeleteExpired(b *testing.B) {
+	b.StopTimer()
+	tc := New(1, 0)
+	tc.mu.Lock()
+	for i := 0; i < b.N; i++ {
+		tc.set(strconv.Itoa(i), "bar", DefaultExpiration)
+	}
+	tc.mu.Unlock()
+	time.Sleep(100)
+	if _, found := tc.Get("0"); found {
+		b.Fatal("0 found")
+	}
+	b.StartTimer()
+	tc.DeleteExpired()
+}

--- a/cache_test.go
+++ b/cache_test.go
@@ -1615,3 +1615,18 @@ func BenchmarkDeleteExpired(b *testing.B) {
 		tc.DeleteExpired()
 	}
 }
+
+func BenchmarkLargeCache(b *testing.B) {
+	b.StopTimer()
+	tc := New(200 * time.Millisecond, 50 * time.Millisecond)
+	//tc.mu.Lock()
+	for i := 0; i < 100000; i++ {
+		tc.set(strconv.Itoa(i), "bar", DefaultExpiration)
+	}
+	//tc.mu.Unlock()
+	tc.DeleteExpired()
+	b.StartTimer()
+	for i := 100000; i <100000 + b.N; i++ {
+		tc.set(strconv.Itoa(i), "bar", DefaultExpiration)
+	}
+}

--- a/cache_test.go
+++ b/cache_test.go
@@ -1604,16 +1604,14 @@ func BenchmarkIncrementInt(b *testing.B) {
 
 func BenchmarkDeleteExpired(b *testing.B) {
 	b.StopTimer()
-	tc := New(1, 0)
+	tc := New(5 * time.Minute, 0)
 	tc.mu.Lock()
-	for i := 0; i < b.N; i++ {
+	for i := 0; i < 100000; i++ {
 		tc.set(strconv.Itoa(i), "bar", DefaultExpiration)
 	}
 	tc.mu.Unlock()
-	time.Sleep(100)
-	if _, found := tc.Get("0"); found {
-		b.Fatal("0 found")
-	}
 	b.StartTimer()
-	tc.DeleteExpired()
+	for i := 0; i < b.N; i++ {
+		tc.DeleteExpired()
+	}
 }

--- a/cache_test.go
+++ b/cache_test.go
@@ -1648,9 +1648,33 @@ func BenchmarkDeleteExpiredLoop(b *testing.B) {
 	}
 }
 
-func BenchmarkLargeCache(b *testing.B) {
+func BenchmarkLargeCache01(b *testing.B) {
+	benchmarkLargeCache(b, 100000)	
+}
+
+func BenchmarkLargeCache02(b *testing.B) {
+	benchmarkLargeCache(b, 200000)	
+}
+
+func BenchmarkLargeCache05(b *testing.B) {
+	benchmarkLargeCache(b, 500000)	
+}
+
+func BenchmarkLargeCache10(b *testing.B) {
+	benchmarkLargeCache(b, 1000000)	
+}
+
+func BenchmarkLargeCache20(b *testing.B) {
+	benchmarkLargeCache(b, 2000000)	
+}
+
+func BenchmarkLargeCache50(b *testing.B) {
+	benchmarkLargeCache(b, 5000000)	
+}
+
+func benchmarkLargeCache(b *testing.B, nano int) {
 	b.StopTimer()
-	tc := New(100*time.Millisecond, 1*time.Millisecond)
+	tc := New(100*time.Millisecond, time.Duration(nano)*time.Nanosecond)
 	b.StartTimer()
 	b.N = 1000000
 	for i := 0; i < b.N; i++ {

--- a/cache_test.go
+++ b/cache_test.go
@@ -1235,10 +1235,15 @@ func TestOnEvicted(t *testing.T) {
 		if k == "foo" && v.(int) == 3 {
 			works = true
 		}
+		tc.Set("bar", 4, DefaultExpiration)
 	})
 	tc.Delete("foo")
+	x, _ := tc.Get("bar")
 	if !works {
 		t.Error("works bool not true")
+	}
+	if x.(int) != 4 {
+		t.Error("bar was not 4")
 	}
 }
 

--- a/cache_test.go
+++ b/cache_test.go
@@ -1680,5 +1680,13 @@ func benchmarkLargeCache(b *testing.B, nano int) {
 	for i := 0; i < b.N; i++ {
 		tc.Set(strconv.Itoa(i), "bar", DefaultExpiration)
 	}
+	b.StopTimer()
+	tc.DeleteExpired()
+	now := time.Now().UnixNano()
+	for _, item := range tc.Items() {
+		if item.Expiration < now {
+			b.Fatalf("some items have not been correctly evicted")
+		}
+	}
 }
 

--- a/cache_test.go
+++ b/cache_test.go
@@ -107,14 +107,14 @@ func TestCacheTimes(t *testing.T) {
 }
 
 func TestNewFrom(t *testing.T) {
-	m := map[string]*Item{
-		"a": &Item{
+	m := map[string]Item{
+		"a": Item{
 			Object:     1,
-			Expiration: nil,
+			Expiration: emptyTime,
 		},
-		"b": &Item{
+		"b": Item{
 			Object:     2,
-			Expiration: nil,
+			Expiration: emptyTime,
 		},
 	}
 	tc := NewFrom(DefaultExpiration, 0, m)

--- a/sharded.go
+++ b/sharded.go
@@ -109,8 +109,8 @@ func (sc *shardedCache) DeleteExpired() {
 // fields of the items should be checked. Note that explicit synchronization
 // is needed to use a cache and its corresponding Items() return values at
 // the same time, as the maps are shared.
-func (sc *shardedCache) Items() []map[string]*Item {
-	res := make([]map[string]*Item, len(sc.cs))
+func (sc *shardedCache) Items() []map[string]Item {
+	res := make([]map[string]Item, len(sc.cs))
 	for i, v := range sc.cs {
 		res[i] = v.Items()
 	}
@@ -171,7 +171,7 @@ func newShardedCache(n int, de time.Duration) *shardedCache {
 	for i := 0; i < n; i++ {
 		c := &cache{
 			defaultExpiration: de,
-			items:             map[string]*Item{},
+			items:             map[string]Item{},
 		}
 		sc.cs[i] = c
 	}

--- a/sharded.go
+++ b/sharded.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"runtime"
 	"time"
+	"github.com/petar/GoLLRB/llrb"
 )
 
 // This is an experimental and unexported (for now) attempt at making a cache
@@ -172,6 +173,7 @@ func newShardedCache(n int, de time.Duration) *shardedCache {
 		c := &cache{
 			defaultExpiration: de,
 			items:             map[string]Item{},
+			sortedItems:		  llrb.New(),
 		}
 		sc.cs[i] = c
 	}

--- a/sharded.go
+++ b/sharded.go
@@ -173,7 +173,7 @@ func newShardedCache(n int, de time.Duration) *shardedCache {
 		c := &cache{
 			defaultExpiration: de,
 			items:             map[string]Item{},
-			sortedItems:		  llrb.New(),
+			sortedItems:       llrb.New(),
 		}
 		sc.cs[i] = c
 	}


### PR DESCRIPTION
Added a BST to the cache data structure. Insertions of new elements, deletions, and expiration changes are slower operations now (O(logn) instead of O(1)). However the bulk removal of expired objects is faster when expired elements are not "too many". 
Examining the tradeoff between these two effects may be a bit tricky. The benchmarks that I introduced seem to indicate that this new version performs better than the original one whenever the bulk deletions remove less than 1% of the of the elements.
Here are my results:

original:

BenchmarkCacheGetExpiring-4                        	        20000000	        74.5 ns/op
BenchmarkCacheGetNotExpiring-4                     	50000000	        37.7 ns/op
BenchmarkRWMutexMapGet-4                           	50000000	        30.5 ns/op
BenchmarkRWMutexInterfaceMapGetStruct-4            	20000000	        84.2 ns/op
BenchmarkRWMutexInterfaceMapGetString-4            	20000000	        82.9 ns/op
BenchmarkCacheGetConcurrentExpiring-4              	20000000	        72.9 ns/op
BenchmarkCacheGetConcurrentNotExpiring-4           	20000000	        62.7 ns/op
BenchmarkRWMutexMapGetConcurrent-4                 	30000000	        54.4 ns/op
BenchmarkCacheGetManyConcurrentExpiring-4          	2000000000	        66.6 ns/op
BenchmarkCacheGetManyConcurrentNotExpiring-4       	30000000	        65.7 ns/op
BenchmarkCacheSetExpiring-4                        	10000000	       237 ns/op
BenchmarkCacheSetNotExpiring-4                     	10000000	       201 ns/op
BenchmarkRWMutexMapSet-4                           	20000000	        89.4 ns/op
BenchmarkCacheSetDelete-4                          	 5000000	       301 ns/op
BenchmarkRWMutexMapSetDelete-4                     	10000000	       179 ns/op
BenchmarkCacheSetDeleteSingleLock-4                	 5000000	       266 ns/op
BenchmarkRWMutexMapSetDeleteSingleLock-4           	10000000	       140 ns/op
BenchmarkIncrementInt-4                            	10000000	       209 ns/op
BenchmarkDeleteExpiredLoop-4                       	     500	   2892388 ns/op
BenchmarkLargeCache01-4                            	 1000000	     27441 ns/op
BenchmarkLargeCache02-4                            	 1000000	     35324 ns/op
BenchmarkLargeCache05-4                            	 1000000	     14706 ns/op
BenchmarkLargeCache10-4                            	 1000000	      8612 ns/op
BenchmarkLargeCache20-4                            	 1000000	      5408 ns/op
BenchmarkLargeCache50-4                            	 1000000	      2729 ns/op
BenchmarkShardedCacheGetExpiring-4                 	20000000	       111 ns/op
BenchmarkShardedCacheGetNotExpiring-4              	20000000	        69.7 ns/op
BenchmarkShardedCacheGetManyConcurrentExpiring-4   	20000000	        76.0 ns/op
BenchmarkShardedCacheGetManyConcurrentNotExpiring-4	20000000	        68.5 ns/op



new:

BenchmarkCacheGetExpiring-4                        	20000000	        75.3 ns/op
BenchmarkCacheGetNotExpiring-4                     	50000000	        37.9 ns/op
BenchmarkRWMutexMapGet-4                           	50000000	        33.8 ns/op
BenchmarkRWMutexInterfaceMapGetStruct-4            	20000000	        81.5 ns/op
BenchmarkRWMutexInterfaceMapGetString-4            	20000000	        80.3 ns/op
BenchmarkCacheGetConcurrentExpiring-4              	20000000	        60.4 ns/op
BenchmarkCacheGetConcurrentNotExpiring-4           	20000000	        63.1 ns/op
BenchmarkRWMutexMapGetConcurrent-4                 	30000000	        57.3 ns/op
BenchmarkCacheGetManyConcurrentExpiring-4          	2000000000	        61.8 ns/op
BenchmarkCacheGetManyConcurrentNotExpiring-4       	30000000	        64.4 ns/op
BenchmarkCacheSetExpiring-4                        	 2000000	       856 ns/op
BenchmarkCacheSetNotExpiring-4                     	10000000	       199 ns/op
BenchmarkRWMutexMapSet-4                           	20000000	        92.6 ns/op
BenchmarkCacheSetDelete-4                          	 3000000	       491 ns/op
BenchmarkRWMutexMapSetDelete-4                     	10000000	       176 ns/op
BenchmarkCacheSetDeleteSingleLock-4                	 3000000	       444 ns/op
BenchmarkRWMutexMapSetDeleteSingleLock-4           	10000000	       144 ns/op
BenchmarkIncrementInt-4                            	10000000	       213 ns/op
BenchmarkDeleteExpiredLoop-4                       	 1000000	      1712 ns/op
BenchmarkLargeCache01-4                            	 1000000	      8704 ns/op
BenchmarkLargeCache02-4                            	 1000000	      8561 ns/op
BenchmarkLargeCache05-4                            	 1000000	      8328 ns/op
BenchmarkLargeCache10-4                            	 1000000	      7837 ns/op
BenchmarkLargeCache20-4                            	 1000000	      7418 ns/op
BenchmarkLargeCache50-4                            	 1000000	      7702 ns/op
BenchmarkShardedCacheGetExpiring-4                 	20000000	       109 ns/op
BenchmarkShardedCacheGetNotExpiring-4              	20000000	        67.4 ns/op
BenchmarkShardedCacheGetManyConcurrentExpiring-4   	2000000000	        50.9 ns/op
BenchmarkShardedCacheGetManyConcurrentNotExpiring-4	100000000	        69.2 ns/op
