### PR TITLE
Add GetWithExpiration(k) (interface{}, time.Time, bool)

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -143,6 +143,28 @@ func (c *cache) get(k string) (interface{}, bool) {
 	return item.Object, true
 }
 
+// GetWithExpiration gets an item from the cache
+// Returns the item or nil, the expiration time and a bool indicating
+// whether the key was found.
+func (c *cache) GetWithExpiration(k string) (Item, time.Time, bool) {
+	c.mu.RLock()
+	// "Inlining" of get and Expired
+	item, found := c.items[k]
+	if !found {
+		c.mu.RUnlock()
+		return Item{}, time.Time{}, false
+	}
+	if item.Expiration > 0 {
+		if time.Now().UnixNano() > item.Expiration {
+			c.mu.RUnlock()
+			return Item{}, time.Time{}, false
+		}
+	}
+	expiration := time.Unix(0, item.Expiration)
+	c.mu.RUnlock()
+	return item, expiration, true
+}
+
 // Increment an item of type int, int8, int16, int32, int64, uintptr, uint,
 // uint8, uint32, or uint64, float32 or float64 by n. Returns an error if the
 // item's value is not an integer, if it was not found, or if it is not


### PR DESCRIPTION
I ran into a concurrency issues using `cache.Items()` the documentation said you needed to synchronize access, but I don't think there's a safe way to do that, especially with a cleanup goroutine modifying the map.

Specifically I was getting nil pointer access panics using it with a lot of concurrent goroutines.
- https://github.com/ulule/limiter/issues/17#issuecomment-182262296

https://github.com/dougnukem/limiter/blob/concurrency_issue/store_memory.go#L36
```
...
item, found := s.Cache.Items()[key]
```

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x0 pc=0x5e304]

goroutine 555 [running]:
github.com/ulule/limiter.(*MemoryStore).Get(0xc82000bba0, 0xc820866920, 0x18, 0x0, 0x0, 0xa, 0x186a0, 0x0, 0x0, 0x0, ...)
    /Users/ddaniels/dev/src/github.com/ulule/limiter/store_memory.go:36 +0x24c
```