### PR TITLE
Add GetWithExpiration

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -6,3 +6,4 @@ code was contributed.)
 Dustin Sallings <dustin@spy.net>
 Jason Mooberry <jasonmoo@me.com>
 Sergey Shepelev <temotor@gmail.com>
+Alex Edwards <ajmedwards@gmail.com>

--- a/cache_test.go
+++ b/cache_test.go
@@ -1459,7 +1459,7 @@ func BenchmarkRWMutexMapGet(b *testing.B) {
 
 func BenchmarkRWMutexInterfaceMapGetStruct(b *testing.B) {
 	b.StopTimer()
-	s := struct{name string}{name: "foo"}
+	s := struct{ name string }{name: "foo"}
 	m := map[interface{}]string{
 		s: "bar",
 	}
@@ -1674,5 +1674,98 @@ func BenchmarkDeleteExpiredLoop(b *testing.B) {
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
 		tc.DeleteExpired()
+	}
+}
+
+func TestGetWithExpiration(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+
+	a, expiration, found := tc.GetWithExpiration("a")
+	if found || a != nil || !expiration.IsZero() {
+		t.Error("Getting A found value that shouldn't exist:", a)
+	}
+
+	b, expiration, found := tc.GetWithExpiration("b")
+	if found || b != nil || !expiration.IsZero() {
+		t.Error("Getting B found value that shouldn't exist:", b)
+	}
+
+	c, expiration, found := tc.GetWithExpiration("c")
+	if found || c != nil || !expiration.IsZero() {
+		t.Error("Getting C found value that shouldn't exist:", c)
+	}
+
+	tc.Set("a", 1, DefaultExpiration)
+	tc.Set("b", "b", DefaultExpiration)
+	tc.Set("c", 3.5, DefaultExpiration)
+	tc.Set("d", 1, NoExpiration)
+	tc.Set("e", 1, 50*time.Millisecond)
+
+	x, expiration, found := tc.GetWithExpiration("a")
+	if !found {
+		t.Error("a was not found while getting a2")
+	}
+	if x == nil {
+		t.Error("x for a is nil")
+	} else if a2 := x.(int); a2+2 != 3 {
+		t.Error("a2 (which should be 1) plus 2 does not equal 3; value:", a2)
+	}
+	if !expiration.IsZero() {
+		t.Error("expiration for a is not a zeroed time")
+	}
+
+	x, expiration, found = tc.GetWithExpiration("b")
+	if !found {
+		t.Error("b was not found while getting b2")
+	}
+	if x == nil {
+		t.Error("x for b is nil")
+	} else if b2 := x.(string); b2+"B" != "bB" {
+		t.Error("b2 (which should be b) plus B does not equal bB; value:", b2)
+	}
+	if !expiration.IsZero() {
+		t.Error("expiration for b is not a zeroed time")
+	}
+
+	x, expiration, found = tc.GetWithExpiration("c")
+	if !found {
+		t.Error("c was not found while getting c2")
+	}
+	if x == nil {
+		t.Error("x for c is nil")
+	} else if c2 := x.(float64); c2+1.2 != 4.7 {
+		t.Error("c2 (which should be 3.5) plus 1.2 does not equal 4.7; value:", c2)
+	}
+	if !expiration.IsZero() {
+		t.Error("expiration for c is not a zeroed time")
+	}
+
+	x, expiration, found = tc.GetWithExpiration("d")
+	if !found {
+		t.Error("d was not found while getting d2")
+	}
+	if x == nil {
+		t.Error("x for d is nil")
+	} else if d2 := x.(int); d2+2 != 3 {
+		t.Error("d (which should be 1) plus 2 does not equal 3; value:", d2)
+	}
+	if !expiration.IsZero() {
+		t.Error("expiration for d is not a zeroed time")
+	}
+
+	x, expiration, found = tc.GetWithExpiration("e")
+	if !found {
+		t.Error("e was not found while getting e2")
+	}
+	if x == nil {
+		t.Error("x for e is nil")
+	} else if e2 := x.(int); e2+2 != 3 {
+		t.Error("e (which should be 1) plus 2 does not equal 3; value:", e2)
+	}
+	if expiration.UnixNano() != tc.items["e"].Expiration {
+		t.Error("expiration for e is not the correct time")
+	}
+	if expiration.UnixNano() < time.Now().UnixNano() {
+		t.Error("expiration for e is in the past")
 	}
 }


### PR DESCRIPTION
PR for issue https://github.com/patrickmn/go-cache/issues/34

The only thing really worth pointing out is the return value when the key never expires (e.g. it was set with NoExpiration). In that scenario I'm returning the zero-value for time.Time, which I thought seemed sensible enough and clients can check easily with Time.IsZero() if they need to.