### PR TITLE
Fix data race

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -1074,7 +1074,6 @@ type janitor struct {
 }
 
 func (j *janitor) Run(c *cache) {
-	j.stop = make(chan bool)
 	ticker := time.NewTicker(j.Interval)
 	for {
 		select {
@@ -1094,6 +1093,7 @@ func stopJanitor(c *Cache) {
 func runJanitor(c *cache, ci time.Duration) {
 	j := &janitor{
 		Interval: ci,
+		stop:     make(chan bool),
 	}
 	c.janitor = j
 	go j.Run(c)


### PR DESCRIPTION
- the gc finalize for an object races with the janitor.Run goroutine
- because the janitor.stop channel is created in the Run() goroutine this leads
  to a data race.
- fix by creating the channel when the janitor is created

cc @Shopify/analytics-stack