### PR TITLE
Delete from the cache on Get if the item expired (to trigger onEvicted)

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -128,6 +128,7 @@ func (c *cache) Get(k string) (interface{}, bool) {
 	if item.Expiration > 0 {
 		if time.Now().UnixNano() > item.Expiration {
 			c.mu.RUnlock()
+			c.Delete(k)
 			return nil, false
 		}
 	}


### PR DESCRIPTION
When we Get from the cache and if the item expired then Delete it to be sure that onEvicted is triggered.