### PR TITLE
fix: data race when go func() in for loop

### DIFF
--- a/cache_test.go
+++ b/cache_test.go
@@ -1563,9 +1563,10 @@ func benchmarkCacheGetManyConcurrent(b *testing.B, exp time.Duration) {
 	wg := new(sync.WaitGroup)
 	wg.Add(n)
 	for _, v := range keys {
+		k := v
 		go func() {
 			for j := 0; j < each; j++ {
-				tc.Get(v)
+				tc.Get(k)
 			}
 			wg.Done()
 		}()

--- a/sharded_test.go
+++ b/sharded_test.go
@@ -7,9 +7,6 @@ import (
 	"time"
 )
 
-// func TestDjb33(t *testing.T) {
-// }
-
 var shardedKeys = []string{
 	"f",
 	"fo",
@@ -73,9 +70,10 @@ func benchmarkShardedCacheGetManyConcurrent(b *testing.B, exp time.Duration) {
 	wg := new(sync.WaitGroup)
 	wg.Add(n)
 	for _, v := range keys {
+		k := v
 		go func() {
 			for j := 0; j < each; j++ {
-				tsc.Get(v)
+				tsc.Get(k)
 			}
 			wg.Done()
 		}()


### PR DESCRIPTION
fix #79 - data race when go func() in for loop

Create a local variable to avoid data race.