### PR TITLE
Add go.mod file declaring proper semantic import path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/patrickmn/go-cache/v2


### PR DESCRIPTION
As the latest version is tagged as `v2.x.x` in git, using the package as a Go module will require importing it as `github.com/patrickmn/go-cache/v2`, otherwise it will show up as:

```
github.com/patrickmn/go-cache v2.1.0+incompatible
```

in a dependent's go.mod.

See: https://github.com/golang/go/wiki/Modules#semantic-import-versioning

I know it's not pretty and introduces more things to maintain manually, but apparently it's what is supposed to be done in this context.