### PR TITLE
GetOrSet method to handle case for atomic get and set if not exists

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -135,6 +135,21 @@ func (c *cache) Get(k string) (interface{}, bool) {
 	return item.Object, true
 }
 
+// GetOrSet an item from the cache or sets default if not found. Returns the
+// existing item or v if none was found, and a bool indicating
+// whether the key was found.
+func (c *cache) GetOrSet(k string, v interface{}, d time.Duration) (interface{}, bool) {
+	c.mu.Lock()
+	item, found := c.get(k)
+	if !found {
+		c.set(k, v, d)
+		c.mu.Unlock()
+		return v, false
+	}
+	c.mu.Unlock()
+	return item, true
+}
+
 // GetWithExpiration returns an item and its expiration time from the cache.
 // It returns the item or nil, the expiration time if one is set (if the item
 // never expires a zero value for time.Time is returned), and a bool indicating

--- a/cache_test.go
+++ b/cache_test.go
@@ -68,6 +68,20 @@ func TestCache(t *testing.T) {
 	}
 }
 
+func TestGetOrSet(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+
+	a, found := tc.GetOrSet("a", "v", DefaultExpiration)
+	if found || a.(string) != "v" {
+		t.Error("Getting a not found value not equal to default", a)
+	}
+
+	a, found = tc.GetOrSet("a", "v2", DefaultExpiration)
+	if !found || a.(string) != "v" {
+		t.Error("Getting a found value not equal to original", a)
+	}
+}
+
 func TestCacheTimes(t *testing.T) {
 	var found bool
 


### PR DESCRIPTION
This PR adds a new method `GetOrSet` to handle the case where we run into a race when multiple threads do "if not found then set" sequence. Without using `GetOrSet`, callers will have to use global locks, then perform 1-2 cache operations (`Add` followed by `Get` if already exists) which would be redundant and inefficient.

There was a similar PR #82 but it tried to do it using a closure instead of a simple value. This PR takes a much simpler approach to avoid potential long held locks by external code.