### PR TITLE
 GetWithExpirationUpdate - atomic implementation

### DIFF
--- a/sharded.go
+++ b/sharded.go
@@ -109,8 +109,8 @@ func (sc *shardedCache) DeleteExpired() {
 // fields of the items should be checked. Note that explicit synchronization
 // is needed to use a cache and its corresponding Items() return values at
 // the same time, as the maps are shared.
-func (sc *shardedCache) Items() []map[string]Item {
-	res := make([]map[string]Item, len(sc.cs))
+func (sc *shardedCache) Items() []map[string]*Item {
+	res := make([]map[string]*Item, len(sc.cs))
 	for i, v := range sc.cs {
 		res[i] = v.Items()
 	}
@@ -171,7 +171,7 @@ func newShardedCache(n int, de time.Duration) *shardedCache {
 	for i := 0; i < n; i++ {
 		c := &cache{
 			defaultExpiration: de,
-			items:             map[string]Item{},
+			items:             map[string]*Item{},
 		}
 		sc.cs[i] = c
 	}


### PR DESCRIPTION
This PR is fixed version of #96. Main changes are:
- Type of `cache.items` are converted from `map[string]Item` to `map[string]*Item`. I needed to do it because, in `GetWithExpirationUpdate`, it is the only way to modify the `Expiration` field of an `Item`. The other way around (re-setting the item) needs a write lock, therefore blocks all reads/writes to `items`. Not convenient for 'cache-get's.
- Now every `Item` has its own `RWLock`. This way, we don't need a write lock in `GetWithExpirationUpdate`. 

Supersedes #125 