### PR TITLE
WIP: Converting to generics proof of concept

### DIFF
--- a/cache.go2
+++ b/cache.go2
@@ -1,22 +1,24 @@
-package cache
+package main
 
 import (
 	"encoding/gob"
 	"fmt"
 	"io"
 	"os"
-	"runtime"
+	//"runtime"
 	"sync"
 	"time"
 )
 
-type Item struct {
-	Object     interface{}
+type Item(type T ) struct {
+	Object     T
 	Expiration int64
 }
 
+type ItemMap(type T ) map[string]Item(T)
+
 // Returns true if the item has expired.
-func (item Item) Expired() bool {
+func (item Item(T)) Expired() bool {
 	if item.Expiration == 0 {
 		return false
 	}
@@ -32,23 +34,23 @@ const (
 	DefaultExpiration time.Duration = 0
 )
 
-type Cache struct {
-	*cache
+type Cache(type T ) struct {
+	*cache(T)
 	// If this is confusing, see the comment at the bottom of New()
 }
 
-type cache struct {
+type cache(type T ) struct {
 	defaultExpiration time.Duration
-	items             map[string]Item
+	items             map[string]Item(T)
 	mu                sync.RWMutex
-	onEvicted         func(string, interface{})
-	janitor           *janitor
+	onEvicted         func(string, T)
+	janitor           *janitor(T)
 }
 
 // Add an item to the cache, replacing any existing item. If the duration is 0
 // (DefaultExpiration), the cache's default expiration time is used. If it is -1
 // (NoExpiration), the item never expires.
-func (c *cache) Set(k string, x interface{}, d time.Duration) {
+func (c *cache(T)) Set(k string, x T, d time.Duration) {
 	// "Inlining" of set
 	var e int64
 	if d == DefaultExpiration {
@@ -58,7 +60,7 @@ func (c *cache) Set(k string, x interface{}, d time.Duration) {
 		e = time.Now().Add(d).UnixNano()
 	}
 	c.mu.Lock()
-	c.items[k] = Item{
+	c.items[k] = Item(T){
 		Object:     x,
 		Expiration: e,
 	}
@@ -67,7 +69,7 @@ func (c *cache) Set(k string, x interface{}, d time.Duration) {
 	c.mu.Unlock()
 }
 
-func (c *cache) set(k string, x interface{}, d time.Duration) {
+func (c *cache(T)) set(k string, x T, d time.Duration) {
 	var e int64
 	if d == DefaultExpiration {
 		d = c.defaultExpiration
@@ -75,7 +77,7 @@ func (c *cache) set(k string, x interface{}, d time.Duration) {
 	if d > 0 {
 		e = time.Now().Add(d).UnixNano()
 	}
-	c.items[k] = Item{
+	c.items[k] = Item(T){
 		Object:     x,
 		Expiration: e,
 	}
@@ -83,13 +85,13 @@ func (c *cache) set(k string, x interface{}, d time.Duration) {
 
 // Add an item to the cache, replacing any existing item, using the default
 // expiration.
-func (c *cache) SetDefault(k string, x interface{}) {
+func (c *cache(T)) SetDefault(k string, x T) {
 	c.Set(k, x, DefaultExpiration)
 }
 
 // Add an item to the cache only if an item doesn't already exist for the given
 // key, or if the existing item has expired. Returns an error otherwise.
-func (c *cache) Add(k string, x interface{}, d time.Duration) error {
+func (c *cache(T)) Add(k string, x T, d time.Duration) error {
 	c.mu.Lock()
 	_, found := c.get(k)
 	if found {
@@ -103,7 +105,7 @@ func (c *cache) Add(k string, x interface{}, d time.Duration) error {
 
 // Set a new value for the cache key only if it already exists, and the existing
 // item hasn't expired. Returns an error otherwise.
-func (c *cache) Replace(k string, x interface{}, d time.Duration) error {
+func (c *cache(T)) Replace(k string, x T, d time.Duration) error {
 	c.mu.Lock()
 	_, found := c.get(k)
 	if !found {
@@ -117,18 +119,20 @@ func (c *cache) Replace(k string, x interface{}, d time.Duration) error {
 
 // Get an item from the cache. Returns the item or nil, and a bool indicating
 // whether the key was found.
-func (c *cache) Get(k string) (interface{}, bool) {
+func (c *cache(T)) Get(k string) (T, bool) {
 	c.mu.RLock()
 	// "Inlining" of get and Expired
 	item, found := c.items[k]
 	if !found {
 		c.mu.RUnlock()
-		return nil, false
+        var zero T
+		return zero, false
 	}
 	if item.Expiration > 0 {
 		if time.Now().UnixNano() > item.Expiration {
 			c.mu.RUnlock()
-			return nil, false
+            var zero T
+			return zero, false
 		}
 	}
 	c.mu.RUnlock()
@@ -136,22 +140,24 @@ func (c *cache) Get(k string) (interface{}, bool) {
 }
 
 // GetWithExpiration returns an item and its expiration time from the cache.
-// It returns the item or nil, the expiration time if one is set (if the item
+// It returns the item or the zero value, the expiration time if one is set (if the item
 // never expires a zero value for time.Time is returned), and a bool indicating
 // whether the key was found.
-func (c *cache) GetWithExpiration(k string) (interface{}, time.Time, bool) {
+func (c *cache(T)) GetWithExpiration(k string) (T, time.Time, bool) {
 	c.mu.RLock()
 	// "Inlining" of get and Expired
 	item, found := c.items[k]
 	if !found {
 		c.mu.RUnlock()
-		return nil, time.Time{}, false
+        var zero T
+		return zero, time.Time{}, false
 	}
 
 	if item.Expiration > 0 {
 		if time.Now().UnixNano() > item.Expiration {
 			c.mu.RUnlock()
-			return nil, time.Time{}, false
+            var zero T
+			return zero, time.Time{}, false
 		}
 
 		// Return the item and the expiration time
@@ -165,63 +171,36 @@ func (c *cache) GetWithExpiration(k string) (interface{}, time.Time, bool) {
 	return item.Object, time.Time{}, true
 }
 
-func (c *cache) get(k string) (interface{}, bool) {
+func (c *cache(T)) get(k string) (T, bool) {
 	item, found := c.items[k]
+    var zero T
 	if !found {
-		return nil, false
+		return zero, false
 	}
 	// "Inlining" of Expired
 	if item.Expiration > 0 {
 		if time.Now().UnixNano() > item.Expiration {
-			return nil, false
+			return zero, false
 		}
 	}
 	return item.Object, true
 }
 
+/*
 // Increment an item of type int, int8, int16, int32, int64, uintptr, uint,
 // uint8, uint32, or uint64, float32 or float64 by n. Returns an error if the
 // item's value is not an integer, if it was not found, or if it is not
 // possible to increment it by n. To retrieve the incremented value, use one
 // of the specialized methods, e.g. IncrementInt64.
-func (c *cache) Increment(k string, n int64) error {
+func (c *cache(T)) Increment(k string, n T) error {
 	c.mu.Lock()
 	v, found := c.items[k]
 	if !found || v.Expired() {
 		c.mu.Unlock()
 		return fmt.Errorf("Item %s not found", k)
 	}
-	switch v.Object.(type) {
-	case int:
-		v.Object = v.Object.(int) + int(n)
-	case int8:
-		v.Object = v.Object.(int8) + int8(n)
-	case int16:
-		v.Object = v.Object.(int16) + int16(n)
-	case int32:
-		v.Object = v.Object.(int32) + int32(n)
-	case int64:
-		v.Object = v.Object.(int64) + n
-	case uint:
-		v.Object = v.Object.(uint) + uint(n)
-	case uintptr:
-		v.Object = v.Object.(uintptr) + uintptr(n)
-	case uint8:
-		v.Object = v.Object.(uint8) + uint8(n)
-	case uint16:
-		v.Object = v.Object.(uint16) + uint16(n)
-	case uint32:
-		v.Object = v.Object.(uint32) + uint32(n)
-	case uint64:
-		v.Object = v.Object.(uint64) + uint64(n)
-	case float32:
-		v.Object = v.Object.(float32) + float32(n)
-	case float64:
-		v.Object = v.Object.(float64) + float64(n)
-	default:
-		c.mu.Unlock()
-		return fmt.Errorf("The value for %s is not an integer", k)
-	}
+    // TODO: How to make this work
+    v.Object += n
 	c.items[k] = v
 	c.mu.Unlock()
 	return nil
@@ -900,9 +879,10 @@ func (c *cache) DecrementFloat64(k string, n float64) (float64, error) {
 	c.mu.Unlock()
 	return nv, nil
 }
+*/
 
 // Delete an item from the cache. Does nothing if the key is not in the cache.
-func (c *cache) Delete(k string) {
+func (c *cache(T)) Delete(k string) {
 	c.mu.Lock()
 	v, evicted := c.delete(k)
 	c.mu.Unlock()
@@ -911,7 +891,7 @@ func (c *cache) Delete(k string) {
 	}
 }
 
-func (c *cache) delete(k string) (interface{}, bool) {
+func (c *cache(T)) delete(k string) (T, bool) {
 	if c.onEvicted != nil {
 		if v, found := c.items[k]; found {
 			delete(c.items, k)
@@ -919,17 +899,18 @@ func (c *cache) delete(k string) (interface{}, bool) {
 		}
 	}
 	delete(c.items, k)
-	return nil, false
+    var zero T
+	return zero, false
 }
 
-type keyAndValue struct {
+type keyAndValue(type T) struct {
 	key   string
-	value interface{}
+	value T
 }
 
 // Delete all expired items from the cache.
-func (c *cache) DeleteExpired() {
-	var evictedItems []keyAndValue
+func (c *cache(T)) DeleteExpired() {
+	var evictedItems []keyAndValue(T)
 	now := time.Now().UnixNano()
 	c.mu.Lock()
 	for k, v := range c.items {
@@ -937,7 +918,7 @@ func (c *cache) DeleteExpired() {
 		if v.Expiration > 0 && now > v.Expiration {
 			ov, evicted := c.delete(k)
 			if evicted {
-				evictedItems = append(evictedItems, keyAndValue{k, ov})
+				evictedItems = append(evictedItems, keyAndValue(T){k, ov})
 			}
 		}
 	}
@@ -950,7 +931,7 @@ func (c *cache) DeleteExpired() {
 // Sets an (optional) function that is called with the key and value when an
 // item is evicted from the cache. (Including when it is deleted manually, but
 // not when it is overwritten.) Set to nil to disable.
-func (c *cache) OnEvicted(f func(string, interface{})) {
+func (c *cache(T)) OnEvicted(f func(string, T)) {
 	c.mu.Lock()
 	c.onEvicted = f
 	c.mu.Unlock()
@@ -960,7 +941,7 @@ func (c *cache) OnEvicted(f func(string, interface{})) {
 //
 // NOTE: This method is deprecated in favor of c.Items() and NewFrom() (see the
 // documentation for NewFrom().)
-func (c *cache) Save(w io.Writer) (err error) {
+func (c *cache(T)) Save(w io.Writer) (err error) {
 	enc := gob.NewEncoder(w)
 	defer func() {
 		if x := recover(); x != nil {
@@ -981,7 +962,7 @@ func (c *cache) Save(w io.Writer) (err error) {
 //
 // NOTE: This method is deprecated in favor of c.Items() and NewFrom() (see the
 // documentation for NewFrom().)
-func (c *cache) SaveFile(fname string) error {
+func (c *cache(T)) SaveFile(fname string) error {
 	fp, err := os.Create(fname)
 	if err != nil {
 		return err
@@ -999,9 +980,10 @@ func (c *cache) SaveFile(fname string) error {
 //
 // NOTE: This method is deprecated in favor of c.Items() and NewFrom() (see the
 // documentation for NewFrom().)
-func (c *cache) Load(r io.Reader) error {
+func (c *cache(T)) Load(r io.Reader) error {
 	dec := gob.NewDecoder(r)
-	items := map[string]Item{}
+	var items map[string]Item(T)
+
 	err := dec.Decode(&items)
 	if err == nil {
 		c.mu.Lock()
@@ -1021,7 +1003,7 @@ func (c *cache) Load(r io.Reader) error {
 //
 // NOTE: This method is deprecated in favor of c.Items() and NewFrom() (see the
 // documentation for NewFrom().)
-func (c *cache) LoadFile(fname string) error {
+func (c *cache(T)) LoadFile(fname string) error {
 	fp, err := os.Open(fname)
 	if err != nil {
 		return err
@@ -1035,10 +1017,10 @@ func (c *cache) LoadFile(fname string) error {
 }
 
 // Copies all unexpired items in the cache into a new map and returns it.
-func (c *cache) Items() map[string]Item {
+func (c *cache(T)) Items() map[string]Item(T) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	m := make(map[string]Item, len(c.items))
+	m := make(ItemMap(T), len(c.items))
 	now := time.Now().UnixNano()
 	for k, v := range c.items {
 		// "Inlining" of Expired
@@ -1054,7 +1036,7 @@ func (c *cache) Items() map[string]Item {
 
 // Returns the number of items in the cache. This may include items that have
 // expired, but have not yet been cleaned up.
-func (c *cache) ItemCount() int {
+func (c *cache(T)) ItemCount() int {
 	c.mu.RLock()
 	n := len(c.items)
 	c.mu.RUnlock()
@@ -1062,18 +1044,18 @@ func (c *cache) ItemCount() int {
 }
 
 // Delete all items from the cache.
-func (c *cache) Flush() {
+func (c *cache(T)) Flush() {
 	c.mu.Lock()
-	c.items = map[string]Item{}
+	c.items = make(ItemMap(T))
 	c.mu.Unlock()
 }
 
-type janitor struct {
+type janitor(type T ) struct {
 	Interval time.Duration
 	stop     chan bool
 }
 
-func (j *janitor) Run(c *cache) {
+func (j *janitor(T)) Run(c *cache(T)) {
 	ticker := time.NewTicker(j.Interval)
 	for {
 		select {
@@ -1086,12 +1068,8 @@ func (j *janitor) Run(c *cache) {
 	}
 }
 
-func stopJanitor(c *Cache) {
-	c.janitor.stop <- true
-}
-
-func runJanitor(c *cache, ci time.Duration) {
-	j := &janitor{
+func runJanitor(type T )(c *cache(T), ci time.Duration) {
+	j := &janitor(T){
 		Interval: ci,
 		stop:     make(chan bool),
 	}
@@ -1099,28 +1077,28 @@ func runJanitor(c *cache, ci time.Duration) {
 	go j.Run(c)
 }
 
-func newCache(de time.Duration, m map[string]Item) *cache {
+func newCache(type T )(de time.Duration, m map[string]Item(T)) *cache(T) {
 	if de == 0 {
 		de = -1
 	}
-	c := &cache{
+	c := &cache(T){
 		defaultExpiration: de,
 		items:             m,
 	}
 	return c
 }
 
-func newCacheWithJanitor(de time.Duration, ci time.Duration, m map[string]Item) *Cache {
-	c := newCache(de, m)
+func newCacheWithJanitor(type T )(de time.Duration, ci time.Duration, m map[string]Item(T)) *Cache(T) {
+	c := newCache(T)(de, m)
 	// This trick ensures that the janitor goroutine (which--granted it
 	// was enabled--is running DeleteExpired on c forever) does not keep
 	// the returned C object from being garbage collected. When it is
 	// garbage collected, the finalizer stops the janitor goroutine, after
 	// which c can be collected.
-	C := &Cache{c}
+	C := &Cache(T){c}
 	if ci > 0 {
 		runJanitor(c, ci)
-		runtime.SetFinalizer(C, stopJanitor)
+		//runtime.SetFinalizer(C, stopJanitor(T))
 	}
 	return C
 }
@@ -1130,8 +1108,8 @@ func newCacheWithJanitor(de time.Duration, ci time.Duration, m map[string]Item) 
 // the items in the cache never expire (by default), and must be deleted
 // manually. If the cleanup interval is less than one, expired items are not
 // deleted from the cache before calling c.DeleteExpired().
-func New(defaultExpiration, cleanupInterval time.Duration) *Cache {
-	items := make(map[string]Item)
+func New(type T)(defaultExpiration, cleanupInterval time.Duration) *Cache(T) {
+	items := make(ItemMap(T))
 	return newCacheWithJanitor(defaultExpiration, cleanupInterval, items)
 }
 
@@ -1156,6 +1134,20 @@ func New(defaultExpiration, cleanupInterval time.Duration) *Cache {
 // gob.Register() the individual types stored in the cache before encoding a
 // map retrieved with c.Items(), and to register those same types before
 // decoding a blob containing an items map.
-func NewFrom(defaultExpiration, cleanupInterval time.Duration, items map[string]Item) *Cache {
+func NewFrom(type T )(defaultExpiration, cleanupInterval time.Duration, items map[string]Item(T)) *Cache(T) {
 	return newCacheWithJanitor(defaultExpiration, cleanupInterval, items)
+}
+
+func main() {
+
+	c := New(string)(5*time.Minute, 10*time.Minute)
+
+	// Set the value of the key "foo" to "bar", with the default expiration time
+	c.cache.Set("foo", "world", DefaultExpiration)
+
+	// Get the string associated with the key "foo" from the cache
+	foo, found := c.cache.Get("foo")
+	if found {
+		fmt.Println("Hello " + foo)
+	}
 }

--- a/cache_test.go2
+++ b/cache_test.go2
@@ -1,4 +1,4 @@
-package cache
+package main
 
 import (
 	"bytes"

--- a/sharded.go2
+++ b/sharded.go2
@@ -1,4 +1,4 @@
-package cache
+package main
 
 import (
 	"crypto/rand"

--- a/sharded_test.go2
+++ b/sharded_test.go2
@@ -1,4 +1,4 @@
-package cache
+package main
 
 import (
 	"strconv"


### PR DESCRIPTION
**NOTE: This is not to be merged until generics make it into mainline go, and even then care will have to be taken with versioning so clients without generics will still be able to compile.**


I wanted to test out the generics proposal for go (https://go.googlesource.com/proposal/+/refs/heads/master/design/go2draft-contracts.md), and I thought a good exercise  would be to try to convert some code into generic code.

Below is a "working" example, which can be run like this (following instructions here: https://go.googlesource.com/go/+/refs/heads/dev.go2go/README.go2go.md)

```
luke@Lukes-MacBook-Air go-cache % ~/goroot/bin/go tool go2go run cache.go2
Hello world
```

Caveats:
1. This is embarrassing but I couldn't figure out how to run this code directly without temporarily changing the package name to `main`. I tried to put it into ~/go2/src and import it into a client project, but it complained about not being able to reference private field `.cache`, see caveat 2. Maybe there's a different way to do it, or maybe caveat 2 has to be addressed first.
2. I'm not sure if this is the go2go tool, but for some reason the go2 code needed to address the `.cache` field of `Cache` directly. For example, in my small client implementation at the bottom of cache.go2, if you replace `c.cache.Set` with the appropriate `c.Set` you get this compilation error:
```
cache.go2:1146:2: type *Cache(string) of c does not match *cache(T) (cannot infer T)
```
In general, I don't quite understand how all the methods here are able to be about `cache` and not `Cache`, I guess there's some sort of magic since `cache` is the only value in the struct? However it happens, it looks like that's not working in go2.
3. I needed to define `ItemMap` in lieu of `map[string]Item` due to a limitation in complex inline types in generic go. I asked about this in the go slack (https://gophers.slack.com/archives/C88U9BFDZ/p1598134017011500) and was told that this is the only option.
4. The `runtime.SetFinalizer` didn't work as is, perhaps the same issue as caveat 2, maybe some other thing, I pulled it out for now.
5. I commented out all the `Increment` code; I'm not sure the best approach here. Maybe some sort of `IncrementableCache`, but that seems to defeat the purpose of generic code :) I wonder if there's a way to define these methods and have *client* code fail to compile if they try to call Increment() on a cache they set up with e.g. strings or something?
6. I haven't touched the tests or the `sharded` file, other than to rename them to `.go2` which is required by the go2go tool.