### PR TITLE
Delete expired items before setting

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -74,8 +74,8 @@ func (c *cache) Set(k string, x interface{}, d time.Duration) {
 	// adds ~200 ns (as of go1.)
 	c.mu.Unlock()
 
-	// try to call onEvicted if key existed before but it was expired before cleanup
-	if evicted && item.Expired() {
+	// try to call onEvicted if key existed before but the item is different
+	if evicted && item.Object != x {
 		c.onEvicted(k, item.Object)
 	}
 }

--- a/cache_test.go
+++ b/cache_test.go
@@ -1265,11 +1265,9 @@ func TestOnEvictedCalledBeforeSet(t *testing.T) {
 		t.Fatal("tc.onEvicted is nil")
 	}
 
-	// ensure item expires
-	time.Sleep(expiry)
-
-	// calling Set again should evict expired item
-	tc.Set("foo", 3, DefaultExpiration)
+	// calling Set again with the same key should evict
+	// the item if different
+	tc.Set("foo", 5, DefaultExpiration)
 
 	x, _ := tc.Get("bar")
 	if !works {

--- a/cache_test.go
+++ b/cache_test.go
@@ -1247,6 +1247,39 @@ func TestOnEvicted(t *testing.T) {
 	}
 }
 
+func TestOnEvictedCalledBeforeSet(t *testing.T) {
+	tc := New(DefaultExpiration, 0)
+	expiry := 1 * time.Nanosecond
+
+	works := false
+	tc.OnEvicted(func(k string, v interface{}) {
+		if k == "foo" && v.(int) == 3 {
+
+			works = true
+		}
+		tc.Set("bar", 4, DefaultExpiration)
+	})
+
+	tc.Set("foo", 3, expiry)
+	if tc.onEvicted == nil {
+		t.Fatal("tc.onEvicted is nil")
+	}
+
+	// ensure item expires
+	time.Sleep(expiry)
+
+	// calling Set again should evict expired item
+	tc.Set("foo", 3, DefaultExpiration)
+
+	x, _ := tc.Get("bar")
+	if !works {
+		t.Fatal("works bool not true")
+	}
+	if x.(int) != 4 {
+		t.Error("bar was not 4")
+	}
+}
+
 func TestCacheSerialization(t *testing.T) {
 	tc := New(DefaultExpiration, 0)
 	testFillAndSerialize(t, tc)


### PR DESCRIPTION
Check if an item exists and it has expired before setting so that
onEvicted is actually called.

Fixes #48.