### PR TITLE
First pass at implementing generics

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -184,17 +184,15 @@ func (c *cache[T]) get(k string) (T, bool) {
 	return item.Object, true
 }
 
-type Incrementable interface {
-	~int | ~int8 | ~int16 | ~int32 | ~int64 | ~uintptr | ~uint | ~uint8 | ~uint32 | ~uint64 | ~float32 | ~float64
-}
-
-// Can't decrement unsigned values
-type Decrementable interface {
-	~int | ~int8 | ~int16 | ~int32 | ~int64 | ~float32 | ~float64
-}
-
-
+// Increment and return an item of type int, int8, int16, int32, int64, uintptr, uint,
+// uint8, uint32, or uint64, float32 or float64 by n. Returns an error if the
+// item's value is not an integer, if it was not found, or if it is not
+// possible to increment it by n.
 func (c *cache[T]) Increment(k string, n int64) (T, error) {
+
+	// TODO: Consider adding a constraint to avoid the type switch and provide
+	// compile-time safety
+	
 	c.mu.Lock()
 	var zero T
 	v, found := c.items[k]
@@ -244,7 +242,14 @@ func (c *cache[T]) Increment(k string, n int64) (T, error) {
 	return zero, nil
 }
 
+// Decrement and return an item of type int, int8, int16, int32, int64, uintptr, uint,
+// uint8, uint32, or uint64, float32 or float64 by n. Returns an error if the
+// item's value is not an integer, if it was not found, or if it is not
+// possible to decrement it by n.
 func (c *cache[T]) Decrement(k string, n int64) (T, error) {
+
+	// TODO: Consider adding a constraint to avoid the type switch and provide
+	// compile-time safety
 	c.mu.Lock()
 	var zero T
 	v, found := c.items[k]

--- a/cache.go
+++ b/cache.go
@@ -1,22 +1,22 @@
 package cache
 
 import (
-	"encoding/gob"
+//	"encoding/gob"
 	"fmt"
-	"io"
-	"os"
+//	"io"
+//	"os"
 	"runtime"
 	"sync"
 	"time"
 )
 
-type Item struct {
-	Object     interface{}
+type Item [T comparable] struct {
+	Object     T
 	Expiration int64
 }
 
 // Returns true if the item has expired.
-func (item Item) Expired() bool {
+func (item Item[T]) Expired() bool {
 	if item.Expiration == 0 {
 		return false
 	}
@@ -32,23 +32,25 @@ const (
 	DefaultExpiration time.Duration = 0
 )
 
-type Cache struct {
-	*cache
+type Cache [T comparable] struct {
+	*cache[T]
 	// If this is confusing, see the comment at the bottom of New()
 }
 
-type cache struct {
+
+
+type cache [T comparable] struct {
 	defaultExpiration time.Duration
-	items             map[string]Item
+	items             map[string]Item[T]
 	mu                sync.RWMutex
-	onEvicted         func(string, interface{})
+	onEvicted         func(string, T)
 	janitor           *janitor
 }
 
 // Add an item to the cache, replacing any existing item. If the duration is 0
 // (DefaultExpiration), the cache's default expiration time is used. If it is -1
 // (NoExpiration), the item never expires.
-func (c *cache) Set(k string, x interface{}, d time.Duration) {
+func (c *cache[T]) Set(k string, x T, d time.Duration) {
 	// "Inlining" of set
 	var e int64
 	if d == DefaultExpiration {
@@ -58,7 +60,7 @@ func (c *cache) Set(k string, x interface{}, d time.Duration) {
 		e = time.Now().Add(d).UnixNano()
 	}
 	c.mu.Lock()
-	c.items[k] = Item{
+	c.items[k] = Item[T]{
 		Object:     x,
 		Expiration: e,
 	}
@@ -67,7 +69,7 @@ func (c *cache) Set(k string, x interface{}, d time.Duration) {
 	c.mu.Unlock()
 }
 
-func (c *cache) set(k string, x interface{}, d time.Duration) {
+func (c *cache[T]) set(k string, x T, d time.Duration) {
 	var e int64
 	if d == DefaultExpiration {
 		d = c.defaultExpiration
@@ -75,7 +77,7 @@ func (c *cache) set(k string, x interface{}, d time.Duration) {
 	if d > 0 {
 		e = time.Now().Add(d).UnixNano()
 	}
-	c.items[k] = Item{
+	c.items[k] = Item[T]{
 		Object:     x,
 		Expiration: e,
 	}
@@ -83,13 +85,13 @@ func (c *cache) set(k string, x interface{}, d time.Duration) {
 
 // Add an item to the cache, replacing any existing item, using the default
 // expiration.
-func (c *cache) SetDefault(k string, x interface{}) {
+func (c *cache[T]) SetDefault(k string, x T) {
 	c.Set(k, x, DefaultExpiration)
 }
 
 // Add an item to the cache only if an item doesn't already exist for the given
 // key, or if the existing item has expired. Returns an error otherwise.
-func (c *cache) Add(k string, x interface{}, d time.Duration) error {
+func (c *cache[T]) Add(k string, x T, d time.Duration) error {
 	c.mu.Lock()
 	_, found := c.get(k)
 	if found {
@@ -103,7 +105,7 @@ func (c *cache) Add(k string, x interface{}, d time.Duration) error {
 
 // Set a new value for the cache key only if it already exists, and the existing
 // item hasn't expired. Returns an error otherwise.
-func (c *cache) Replace(k string, x interface{}, d time.Duration) error {
+func (c *cache[T]) Replace(k string, x T, d time.Duration) error {
 	c.mu.Lock()
 	_, found := c.get(k)
 	if !found {
@@ -117,18 +119,19 @@ func (c *cache) Replace(k string, x interface{}, d time.Duration) error {
 
 // Get an item from the cache. Returns the item or nil, and a bool indicating
 // whether the key was found.
-func (c *cache) Get(k string) (interface{}, bool) {
+func (c *cache[T]) Get(k string) (T, bool) {
 	c.mu.RLock()
+	var zero T
 	// "Inlining" of get and Expired
 	item, found := c.items[k]
 	if !found {
 		c.mu.RUnlock()
-		return nil, false
+		return zero, false
 	}
 	if item.Expiration > 0 {
 		if time.Now().UnixNano() > item.Expiration {
 			c.mu.RUnlock()
-			return nil, false
+			return zero, false
 		}
 	}
 	c.mu.RUnlock()
@@ -139,19 +142,20 @@ func (c *cache) Get(k string) (interface{}, bool) {
 // It returns the item or nil, the expiration time if one is set (if the item
 // never expires a zero value for time.Time is returned), and a bool indicating
 // whether the key was found.
-func (c *cache) GetWithExpiration(k string) (interface{}, time.Time, bool) {
+func (c *cache[T]) GetWithExpiration(k string) (T, time.Time, bool) {
 	c.mu.RLock()
+	var zero T
 	// "Inlining" of get and Expired
 	item, found := c.items[k]
 	if !found {
 		c.mu.RUnlock()
-		return nil, time.Time{}, false
+		return zero, time.Time{}, false
 	}
 
 	if item.Expiration > 0 {
 		if time.Now().UnixNano() > item.Expiration {
 			c.mu.RUnlock()
-			return nil, time.Time{}, false
+			return zero, time.Time{}, false
 		}
 
 		// Return the item and the expiration time
@@ -165,744 +169,58 @@ func (c *cache) GetWithExpiration(k string) (interface{}, time.Time, bool) {
 	return item.Object, time.Time{}, true
 }
 
-func (c *cache) get(k string) (interface{}, bool) {
+func (c *cache[T]) get(k string) (T, bool) {
 	item, found := c.items[k]
+	var zero T
 	if !found {
-		return nil, false
+		return zero, false
 	}
 	// "Inlining" of Expired
 	if item.Expiration > 0 {
 		if time.Now().UnixNano() > item.Expiration {
-			return nil, false
+			return zero, false
 		}
 	}
 	return item.Object, true
 }
 
-// Increment an item of type int, int8, int16, int32, int64, uintptr, uint,
-// uint8, uint32, or uint64, float32 or float64 by n. Returns an error if the
-// item's value is not an integer, if it was not found, or if it is not
-// possible to increment it by n. To retrieve the incremented value, use one
-// of the specialized methods, e.g. IncrementInt64.
-func (c *cache) Increment(k string, n int64) error {
+type Incrementable interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 | ~uintptr | ~uint | ~uint8 | ~uint32 | ~uint64 | ~float32 | ~float64
+}
+
+// Can't decrement unsigned values
+type Decrementable interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 | ~float32 | ~float64
+}
+
+func Increment[I Incrementable](c *Cache[I], k string, n I) error {
 	c.mu.Lock()
 	v, found := c.items[k]
 	if !found || v.Expired() {
 		c.mu.Unlock()
 		return fmt.Errorf("Item %s not found", k)
 	}
-	switch v.Object.(type) {
-	case int:
-		v.Object = v.Object.(int) + int(n)
-	case int8:
-		v.Object = v.Object.(int8) + int8(n)
-	case int16:
-		v.Object = v.Object.(int16) + int16(n)
-	case int32:
-		v.Object = v.Object.(int32) + int32(n)
-	case int64:
-		v.Object = v.Object.(int64) + n
-	case uint:
-		v.Object = v.Object.(uint) + uint(n)
-	case uintptr:
-		v.Object = v.Object.(uintptr) + uintptr(n)
-	case uint8:
-		v.Object = v.Object.(uint8) + uint8(n)
-	case uint16:
-		v.Object = v.Object.(uint16) + uint16(n)
-	case uint32:
-		v.Object = v.Object.(uint32) + uint32(n)
-	case uint64:
-		v.Object = v.Object.(uint64) + uint64(n)
-	case float32:
-		v.Object = v.Object.(float32) + float32(n)
-	case float64:
-		v.Object = v.Object.(float64) + float64(n)
-	default:
-		c.mu.Unlock()
-		return fmt.Errorf("The value for %s is not an integer", k)
-	}
+	v.Object = v.Object + n
 	c.items[k] = v
 	c.mu.Unlock()
 	return nil
 }
 
-// Increment an item of type float32 or float64 by n. Returns an error if the
-// item's value is not floating point, if it was not found, or if it is not
-// possible to increment it by n. Pass a negative number to decrement the
-// value. To retrieve the incremented value, use one of the specialized methods,
-// e.g. IncrementFloat64.
-func (c *cache) IncrementFloat(k string, n float64) error {
+func Decrement[D Decrementable](c *Cache[D], k string, n D) error {
 	c.mu.Lock()
 	v, found := c.items[k]
 	if !found || v.Expired() {
 		c.mu.Unlock()
 		return fmt.Errorf("Item %s not found", k)
 	}
-	switch v.Object.(type) {
-	case float32:
-		v.Object = v.Object.(float32) + float32(n)
-	case float64:
-		v.Object = v.Object.(float64) + n
-	default:
-		c.mu.Unlock()
-		return fmt.Errorf("The value for %s does not have type float32 or float64", k)
-	}
+	v.Object = v.Object - n
 	c.items[k] = v
 	c.mu.Unlock()
 	return nil
-}
-
-// Increment an item of type int by n. Returns an error if the item's value is
-// not an int, or if it was not found. If there is no error, the incremented
-// value is returned.
-func (c *cache) IncrementInt(k string, n int) (int, error) {
-	c.mu.Lock()
-	v, found := c.items[k]
-	if !found || v.Expired() {
-		c.mu.Unlock()
-		return 0, fmt.Errorf("Item %s not found", k)
-	}
-	rv, ok := v.Object.(int)
-	if !ok {
-		c.mu.Unlock()
-		return 0, fmt.Errorf("The value for %s is not an int", k)
-	}
-	nv := rv + n
-	v.Object = nv
-	c.items[k] = v
-	c.mu.Unlock()
-	return nv, nil
-}
-
-// Increment an item of type int8 by n. Returns an error if the item's value is
-// not an int8, or if it was not found. If there is no error, the incremented
-// value is returned.
-func (c *cache) IncrementInt8(k string, n int8) (int8, error) {
-	c.mu.Lock()
-	v, found := c.items[k]
-	if !found || v.Expired() {
-		c.mu.Unlock()
-		return 0, fmt.Errorf("Item %s not found", k)
-	}
-	rv, ok := v.Object.(int8)
-	if !ok {
-		c.mu.Unlock()
-		return 0, fmt.Errorf("The value for %s is not an int8", k)
-	}
-	nv := rv + n
-	v.Object = nv
-	c.items[k] = v
-	c.mu.Unlock()
-	return nv, nil
-}
-
-// Increment an item of type int16 by n. Returns an error if the item's value is
-// not an int16, or if it was not found. If there is no error, the incremented
-// value is returned.
-func (c *cache) IncrementInt16(k string, n int16) (int16, error) {
-	c.mu.Lock()
-	v, found := c.items[k]
-	if !found || v.Expired() {
-		c.mu.Unlock()
-		return 0, fmt.Errorf("Item %s not found", k)
-	}
-	rv, ok := v.Object.(int16)
-	if !ok {
-		c.mu.Unlock()
-		return 0, fmt.Errorf("The value for %s is not an int16", k)
-	}
-	nv := rv + n
-	v.Object = nv
-	c.items[k] = v
-	c.mu.Unlock()
-	return nv, nil
-}
-
-// Increment an item of type int32 by n. Returns an error if the item's value is
-// not an int32, or if it was not found. If there is no error, the incremented
-// value is returned.
-func (c *cache) IncrementInt32(k string, n int32) (int32, error) {
-	c.mu.Lock()
-	v, found := c.items[k]
-	if !found || v.Expired() {
-		c.mu.Unlock()
-		return 0, fmt.Errorf("Item %s not found", k)
-	}
-	rv, ok := v.Object.(int32)
-	if !ok {
-		c.mu.Unlock()
-		return 0, fmt.Errorf("The value for %s is not an int32", k)
-	}
-	nv := rv + n
-	v.Object = nv
-	c.items[k] = v
-	c.mu.Unlock()
-	return nv, nil
-}
-
-// Increment an item of type int64 by n. Returns an error if the item's value is
-// not an int64, or if it was not found. If there is no error, the incremented
-// value is returned.
-func (c *cache) IncrementInt64(k string, n int64) (int64, error) {
-	c.mu.Lock()
-	v, found := c.items[k]
-	if !found || v.Expired() {
-		c.mu.Unlock()
-		return 0, fmt.Errorf("Item %s not found", k)
-	}
-	rv, ok := v.Object.(int64)
-	if !ok {
-		c.mu.Unlock()
-		return 0, fmt.Errorf("The value for %s is not an int64", k)
-	}
-	nv := rv + n
-	v.Object = nv
-	c.items[k] = v
-	c.mu.Unlock()
-	return nv, nil
-}
-
-// Increment an item of type uint by n. Returns an error if the item's value is
-// not an uint, or if it was not found. If there is no error, the incremented
-// value is returned.
-func (c *cache) IncrementUint(k string, n uint) (uint, error) {
-	c.mu.Lock()
-	v, found := c.items[k]
-	if !found || v.Expired() {
-		c.mu.Unlock()
-		return 0, fmt.Errorf("Item %s not found", k)
-	}
-	rv, ok := v.Object.(uint)
-	if !ok {
-		c.mu.Unlock()
-		return 0, fmt.Errorf("The value for %s is not an uint", k)
-	}
-	nv := rv + n
-	v.Object = nv
-	c.items[k] = v
-	c.mu.Unlock()
-	return nv, nil
-}
-
-// Increment an item of type uintptr by n. Returns an error if the item's value
-// is not an uintptr, or if it was not found. If there is no error, the
-// incremented value is returned.
-func (c *cache) IncrementUintptr(k string, n uintptr) (uintptr, error) {
-	c.mu.Lock()
-	v, found := c.items[k]
-	if !found || v.Expired() {
-		c.mu.Unlock()
-		return 0, fmt.Errorf("Item %s not found", k)
-	}
-	rv, ok := v.Object.(uintptr)
-	if !ok {
-		c.mu.Unlock()
-		return 0, fmt.Errorf("The value for %s is not an uintptr", k)
-	}
-	nv := rv + n
-	v.Object = nv
-	c.items[k] = v
-	c.mu.Unlock()
-	return nv, nil
-}
-
-// Increment an item of type uint8 by n. Returns an error if the item's value
-// is not an uint8, or if it was not found. If there is no error, the
-// incremented value is returned.
-func (c *cache) IncrementUint8(k string, n uint8) (uint8, error) {
-	c.mu.Lock()
-	v, found := c.items[k]
-	if !found || v.Expired() {
-		c.mu.Unlock()
-		return 0, fmt.Errorf("Item %s not found", k)
-	}
-	rv, ok := v.Object.(uint8)
-	if !ok {
-		c.mu.Unlock()
-		return 0, fmt.Errorf("The value for %s is not an uint8", k)
-	}
-	nv := rv + n
-	v.Object = nv
-	c.items[k] = v
-	c.mu.Unlock()
-	return nv, nil
-}
-
-// Increment an item of type uint16 by n. Returns an error if the item's value
-// is not an uint16, or if it was not found. If there is no error, the
-// incremented value is returned.
-func (c *cache) IncrementUint16(k string, n uint16) (uint16, error) {
-	c.mu.Lock()
-	v, found := c.items[k]
-	if !found || v.Expired() {
-		c.mu.Unlock()
-		return 0, fmt.Errorf("Item %s not found", k)
-	}
-	rv, ok := v.Object.(uint16)
-	if !ok {
-		c.mu.Unlock()
-		return 0, fmt.Errorf("The value for %s is not an uint16", k)
-	}
-	nv := rv + n
-	v.Object = nv
-	c.items[k] = v
-	c.mu.Unlock()
-	return nv, nil
-}
-
-// Increment an item of type uint32 by n. Returns an error if the item's value
-// is not an uint32, or if it was not found. If there is no error, the
-// incremented value is returned.
-func (c *cache) IncrementUint32(k string, n uint32) (uint32, error) {
-	c.mu.Lock()
-	v, found := c.items[k]
-	if !found || v.Expired() {
-		c.mu.Unlock()
-		return 0, fmt.Errorf("Item %s not found", k)
-	}
-	rv, ok := v.Object.(uint32)
-	if !ok {
-		c.mu.Unlock()
-		return 0, fmt.Errorf("The value for %s is not an uint32", k)
-	}
-	nv := rv + n
-	v.Object = nv
-	c.items[k] = v
-	c.mu.Unlock()
-	return nv, nil
-}
-
-// Increment an item of type uint64 by n. Returns an error if the item's value
-// is not an uint64, or if it was not found. If there is no error, the
-// incremented value is returned.
-func (c *cache) IncrementUint64(k string, n uint64) (uint64, error) {
-	c.mu.Lock()
-	v, found := c.items[k]
-	if !found || v.Expired() {
-		c.mu.Unlock()
-		return 0, fmt.Errorf("Item %s not found", k)
-	}
-	rv, ok := v.Object.(uint64)
-	if !ok {
-		c.mu.Unlock()
-		return 0, fmt.Errorf("The value for %s is not an uint64", k)
-	}
-	nv := rv + n
-	v.Object = nv
-	c.items[k] = v
-	c.mu.Unlock()
-	return nv, nil
-}
-
-// Increment an item of type float32 by n. Returns an error if the item's value
-// is not an float32, or if it was not found. If there is no error, the
-// incremented value is returned.
-func (c *cache) IncrementFloat32(k string, n float32) (float32, error) {
-	c.mu.Lock()
-	v, found := c.items[k]
-	if !found || v.Expired() {
-		c.mu.Unlock()
-		return 0, fmt.Errorf("Item %s not found", k)
-	}
-	rv, ok := v.Object.(float32)
-	if !ok {
-		c.mu.Unlock()
-		return 0, fmt.Errorf("The value for %s is not an float32", k)
-	}
-	nv := rv + n
-	v.Object = nv
-	c.items[k] = v
-	c.mu.Unlock()
-	return nv, nil
-}
-
-// Increment an item of type float64 by n. Returns an error if the item's value
-// is not an float64, or if it was not found. If there is no error, the
-// incremented value is returned.
-func (c *cache) IncrementFloat64(k string, n float64) (float64, error) {
-	c.mu.Lock()
-	v, found := c.items[k]
-	if !found || v.Expired() {
-		c.mu.Unlock()
-		return 0, fmt.Errorf("Item %s not found", k)
-	}
-	rv, ok := v.Object.(float64)
-	if !ok {
-		c.mu.Unlock()
-		return 0, fmt.Errorf("The value for %s is not an float64", k)
-	}
-	nv := rv + n
-	v.Object = nv
-	c.items[k] = v
-	c.mu.Unlock()
-	return nv, nil
-}
-
-// Decrement an item of type int, int8, int16, int32, int64, uintptr, uint,
-// uint8, uint32, or uint64, float32 or float64 by n. Returns an error if the
-// item's value is not an integer, if it was not found, or if it is not
-// possible to decrement it by n. To retrieve the decremented value, use one
-// of the specialized methods, e.g. DecrementInt64.
-func (c *cache) Decrement(k string, n int64) error {
-	// TODO: Implement Increment and Decrement more cleanly.
-	// (Cannot do Increment(k, n*-1) for uints.)
-	c.mu.Lock()
-	v, found := c.items[k]
-	if !found || v.Expired() {
-		c.mu.Unlock()
-		return fmt.Errorf("Item not found")
-	}
-	switch v.Object.(type) {
-	case int:
-		v.Object = v.Object.(int) - int(n)
-	case int8:
-		v.Object = v.Object.(int8) - int8(n)
-	case int16:
-		v.Object = v.Object.(int16) - int16(n)
-	case int32:
-		v.Object = v.Object.(int32) - int32(n)
-	case int64:
-		v.Object = v.Object.(int64) - n
-	case uint:
-		v.Object = v.Object.(uint) - uint(n)
-	case uintptr:
-		v.Object = v.Object.(uintptr) - uintptr(n)
-	case uint8:
-		v.Object = v.Object.(uint8) - uint8(n)
-	case uint16:
-		v.Object = v.Object.(uint16) - uint16(n)
-	case uint32:
-		v.Object = v.Object.(uint32) - uint32(n)
-	case uint64:
-		v.Object = v.Object.(uint64) - uint64(n)
-	case float32:
-		v.Object = v.Object.(float32) - float32(n)
-	case float64:
-		v.Object = v.Object.(float64) - float64(n)
-	default:
-		c.mu.Unlock()
-		return fmt.Errorf("The value for %s is not an integer", k)
-	}
-	c.items[k] = v
-	c.mu.Unlock()
-	return nil
-}
-
-// Decrement an item of type float32 or float64 by n. Returns an error if the
-// item's value is not floating point, if it was not found, or if it is not
-// possible to decrement it by n. Pass a negative number to decrement the
-// value. To retrieve the decremented value, use one of the specialized methods,
-// e.g. DecrementFloat64.
-func (c *cache) DecrementFloat(k string, n float64) error {
-	c.mu.Lock()
-	v, found := c.items[k]
-	if !found || v.Expired() {
-		c.mu.Unlock()
-		return fmt.Errorf("Item %s not found", k)
-	}
-	switch v.Object.(type) {
-	case float32:
-		v.Object = v.Object.(float32) - float32(n)
-	case float64:
-		v.Object = v.Object.(float64) - n
-	default:
-		c.mu.Unlock()
-		return fmt.Errorf("The value for %s does not have type float32 or float64", k)
-	}
-	c.items[k] = v
-	c.mu.Unlock()
-	return nil
-}
-
-// Decrement an item of type int by n. Returns an error if the item's value is
-// not an int, or if it was not found. If there is no error, the decremented
-// value is returned.
-func (c *cache) DecrementInt(k string, n int) (int, error) {
-	c.mu.Lock()
-	v, found := c.items[k]
-	if !found || v.Expired() {
-		c.mu.Unlock()
-		return 0, fmt.Errorf("Item %s not found", k)
-	}
-	rv, ok := v.Object.(int)
-	if !ok {
-		c.mu.Unlock()
-		return 0, fmt.Errorf("The value for %s is not an int", k)
-	}
-	nv := rv - n
-	v.Object = nv
-	c.items[k] = v
-	c.mu.Unlock()
-	return nv, nil
-}
-
-// Decrement an item of type int8 by n. Returns an error if the item's value is
-// not an int8, or if it was not found. If there is no error, the decremented
-// value is returned.
-func (c *cache) DecrementInt8(k string, n int8) (int8, error) {
-	c.mu.Lock()
-	v, found := c.items[k]
-	if !found || v.Expired() {
-		c.mu.Unlock()
-		return 0, fmt.Errorf("Item %s not found", k)
-	}
-	rv, ok := v.Object.(int8)
-	if !ok {
-		c.mu.Unlock()
-		return 0, fmt.Errorf("The value for %s is not an int8", k)
-	}
-	nv := rv - n
-	v.Object = nv
-	c.items[k] = v
-	c.mu.Unlock()
-	return nv, nil
-}
-
-// Decrement an item of type int16 by n. Returns an error if the item's value is
-// not an int16, or if it was not found. If there is no error, the decremented
-// value is returned.
-func (c *cache) DecrementInt16(k string, n int16) (int16, error) {
-	c.mu.Lock()
-	v, found := c.items[k]
-	if !found || v.Expired() {
-		c.mu.Unlock()
-		return 0, fmt.Errorf("Item %s not found", k)
-	}
-	rv, ok := v.Object.(int16)
-	if !ok {
-		c.mu.Unlock()
-		return 0, fmt.Errorf("The value for %s is not an int16", k)
-	}
-	nv := rv - n
-	v.Object = nv
-	c.items[k] = v
-	c.mu.Unlock()
-	return nv, nil
-}
-
-// Decrement an item of type int32 by n. Returns an error if the item's value is
-// not an int32, or if it was not found. If there is no error, the decremented
-// value is returned.
-func (c *cache) DecrementInt32(k string, n int32) (int32, error) {
-	c.mu.Lock()
-	v, found := c.items[k]
-	if !found || v.Expired() {
-		c.mu.Unlock()
-		return 0, fmt.Errorf("Item %s not found", k)
-	}
-	rv, ok := v.Object.(int32)
-	if !ok {
-		c.mu.Unlock()
-		return 0, fmt.Errorf("The value for %s is not an int32", k)
-	}
-	nv := rv - n
-	v.Object = nv
-	c.items[k] = v
-	c.mu.Unlock()
-	return nv, nil
-}
-
-// Decrement an item of type int64 by n. Returns an error if the item's value is
-// not an int64, or if it was not found. If there is no error, the decremented
-// value is returned.
-func (c *cache) DecrementInt64(k string, n int64) (int64, error) {
-	c.mu.Lock()
-	v, found := c.items[k]
-	if !found || v.Expired() {
-		c.mu.Unlock()
-		return 0, fmt.Errorf("Item %s not found", k)
-	}
-	rv, ok := v.Object.(int64)
-	if !ok {
-		c.mu.Unlock()
-		return 0, fmt.Errorf("The value for %s is not an int64", k)
-	}
-	nv := rv - n
-	v.Object = nv
-	c.items[k] = v
-	c.mu.Unlock()
-	return nv, nil
-}
-
-// Decrement an item of type uint by n. Returns an error if the item's value is
-// not an uint, or if it was not found. If there is no error, the decremented
-// value is returned.
-func (c *cache) DecrementUint(k string, n uint) (uint, error) {
-	c.mu.Lock()
-	v, found := c.items[k]
-	if !found || v.Expired() {
-		c.mu.Unlock()
-		return 0, fmt.Errorf("Item %s not found", k)
-	}
-	rv, ok := v.Object.(uint)
-	if !ok {
-		c.mu.Unlock()
-		return 0, fmt.Errorf("The value for %s is not an uint", k)
-	}
-	nv := rv - n
-	v.Object = nv
-	c.items[k] = v
-	c.mu.Unlock()
-	return nv, nil
-}
-
-// Decrement an item of type uintptr by n. Returns an error if the item's value
-// is not an uintptr, or if it was not found. If there is no error, the
-// decremented value is returned.
-func (c *cache) DecrementUintptr(k string, n uintptr) (uintptr, error) {
-	c.mu.Lock()
-	v, found := c.items[k]
-	if !found || v.Expired() {
-		c.mu.Unlock()
-		return 0, fmt.Errorf("Item %s not found", k)
-	}
-	rv, ok := v.Object.(uintptr)
-	if !ok {
-		c.mu.Unlock()
-		return 0, fmt.Errorf("The value for %s is not an uintptr", k)
-	}
-	nv := rv - n
-	v.Object = nv
-	c.items[k] = v
-	c.mu.Unlock()
-	return nv, nil
-}
-
-// Decrement an item of type uint8 by n. Returns an error if the item's value is
-// not an uint8, or if it was not found. If there is no error, the decremented
-// value is returned.
-func (c *cache) DecrementUint8(k string, n uint8) (uint8, error) {
-	c.mu.Lock()
-	v, found := c.items[k]
-	if !found || v.Expired() {
-		c.mu.Unlock()
-		return 0, fmt.Errorf("Item %s not found", k)
-	}
-	rv, ok := v.Object.(uint8)
-	if !ok {
-		c.mu.Unlock()
-		return 0, fmt.Errorf("The value for %s is not an uint8", k)
-	}
-	nv := rv - n
-	v.Object = nv
-	c.items[k] = v
-	c.mu.Unlock()
-	return nv, nil
-}
-
-// Decrement an item of type uint16 by n. Returns an error if the item's value
-// is not an uint16, or if it was not found. If there is no error, the
-// decremented value is returned.
-func (c *cache) DecrementUint16(k string, n uint16) (uint16, error) {
-	c.mu.Lock()
-	v, found := c.items[k]
-	if !found || v.Expired() {
-		c.mu.Unlock()
-		return 0, fmt.Errorf("Item %s not found", k)
-	}
-	rv, ok := v.Object.(uint16)
-	if !ok {
-		c.mu.Unlock()
-		return 0, fmt.Errorf("The value for %s is not an uint16", k)
-	}
-	nv := rv - n
-	v.Object = nv
-	c.items[k] = v
-	c.mu.Unlock()
-	return nv, nil
-}
-
-// Decrement an item of type uint32 by n. Returns an error if the item's value
-// is not an uint32, or if it was not found. If there is no error, the
-// decremented value is returned.
-func (c *cache) DecrementUint32(k string, n uint32) (uint32, error) {
-	c.mu.Lock()
-	v, found := c.items[k]
-	if !found || v.Expired() {
-		c.mu.Unlock()
-		return 0, fmt.Errorf("Item %s not found", k)
-	}
-	rv, ok := v.Object.(uint32)
-	if !ok {
-		c.mu.Unlock()
-		return 0, fmt.Errorf("The value for %s is not an uint32", k)
-	}
-	nv := rv - n
-	v.Object = nv
-	c.items[k] = v
-	c.mu.Unlock()
-	return nv, nil
-}
-
-// Decrement an item of type uint64 by n. Returns an error if the item's value
-// is not an uint64, or if it was not found. If there is no error, the
-// decremented value is returned.
-func (c *cache) DecrementUint64(k string, n uint64) (uint64, error) {
-	c.mu.Lock()
-	v, found := c.items[k]
-	if !found || v.Expired() {
-		c.mu.Unlock()
-		return 0, fmt.Errorf("Item %s not found", k)
-	}
-	rv, ok := v.Object.(uint64)
-	if !ok {
-		c.mu.Unlock()
-		return 0, fmt.Errorf("The value for %s is not an uint64", k)
-	}
-	nv := rv - n
-	v.Object = nv
-	c.items[k] = v
-	c.mu.Unlock()
-	return nv, nil
-}
-
-// Decrement an item of type float32 by n. Returns an error if the item's value
-// is not an float32, or if it was not found. If there is no error, the
-// decremented value is returned.
-func (c *cache) DecrementFloat32(k string, n float32) (float32, error) {
-	c.mu.Lock()
-	v, found := c.items[k]
-	if !found || v.Expired() {
-		c.mu.Unlock()
-		return 0, fmt.Errorf("Item %s not found", k)
-	}
-	rv, ok := v.Object.(float32)
-	if !ok {
-		c.mu.Unlock()
-		return 0, fmt.Errorf("The value for %s is not an float32", k)
-	}
-	nv := rv - n
-	v.Object = nv
-	c.items[k] = v
-	c.mu.Unlock()
-	return nv, nil
-}
-
-// Decrement an item of type float64 by n. Returns an error if the item's value
-// is not an float64, or if it was not found. If there is no error, the
-// decremented value is returned.
-func (c *cache) DecrementFloat64(k string, n float64) (float64, error) {
-	c.mu.Lock()
-	v, found := c.items[k]
-	if !found || v.Expired() {
-		c.mu.Unlock()
-		return 0, fmt.Errorf("Item %s not found", k)
-	}
-	rv, ok := v.Object.(float64)
-	if !ok {
-		c.mu.Unlock()
-		return 0, fmt.Errorf("The value for %s is not an float64", k)
-	}
-	nv := rv - n
-	v.Object = nv
-	c.items[k] = v
-	c.mu.Unlock()
-	return nv, nil
 }
 
 // Delete an item from the cache. Does nothing if the key is not in the cache.
-func (c *cache) Delete(k string) {
+func (c *cache[T]) Delete(k string) {
 	c.mu.Lock()
 	v, evicted := c.delete(k)
 	c.mu.Unlock()
@@ -911,7 +229,8 @@ func (c *cache) Delete(k string) {
 	}
 }
 
-func (c *cache) delete(k string) (interface{}, bool) {
+func (c *cache[T]) delete(k string) (T, bool) {
+	var zero T
 	if c.onEvicted != nil {
 		if v, found := c.items[k]; found {
 			delete(c.items, k)
@@ -919,17 +238,17 @@ func (c *cache) delete(k string) (interface{}, bool) {
 		}
 	}
 	delete(c.items, k)
-	return nil, false
+	return zero, false
 }
 
-type keyAndValue struct {
+type keyAndValue[T comparable] struct {
 	key   string
-	value interface{}
+	value T
 }
 
 // Delete all expired items from the cache.
-func (c *cache) DeleteExpired() {
-	var evictedItems []keyAndValue
+func (c *cache[T]) DeleteExpired() {
+	var evictedItems []keyAndValue[T]
 	now := time.Now().UnixNano()
 	c.mu.Lock()
 	for k, v := range c.items {
@@ -937,7 +256,7 @@ func (c *cache) DeleteExpired() {
 		if v.Expiration > 0 && now > v.Expiration {
 			ov, evicted := c.delete(k)
 			if evicted {
-				evictedItems = append(evictedItems, keyAndValue{k, ov})
+				evictedItems = append(evictedItems, keyAndValue[T]{k, ov})
 			}
 		}
 	}
@@ -950,12 +269,13 @@ func (c *cache) DeleteExpired() {
 // Sets an (optional) function that is called with the key and value when an
 // item is evicted from the cache. (Including when it is deleted manually, but
 // not when it is overwritten.) Set to nil to disable.
-func (c *cache) OnEvicted(f func(string, interface{})) {
+func (c *cache[T]) OnEvicted(f func(string, T)) {
 	c.mu.Lock()
 	c.onEvicted = f
 	c.mu.Unlock()
 }
 
+/*
 // Write the cache's items (using Gob) to an io.Writer.
 //
 // NOTE: This method is deprecated in favor of c.Items() and NewFrom() (see the
@@ -1033,12 +353,13 @@ func (c *cache) LoadFile(fname string) error {
 	}
 	return fp.Close()
 }
+*/
 
 // Copies all unexpired items in the cache into a new map and returns it.
-func (c *cache) Items() map[string]Item {
+func (c *cache[T]) Items() map[string]Item[T] {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	m := make(map[string]Item, len(c.items))
+	m := make(map[string]Item[T], len(c.items))
 	now := time.Now().UnixNano()
 	for k, v := range c.items {
 		// "Inlining" of Expired
@@ -1054,7 +375,7 @@ func (c *cache) Items() map[string]Item {
 
 // Returns the number of items in the cache. This may include items that have
 // expired, but have not yet been cleaned up.
-func (c *cache) ItemCount() int {
+func (c *cache[T]) ItemCount() int {
 	c.mu.RLock()
 	n := len(c.items)
 	c.mu.RUnlock()
@@ -1062,9 +383,9 @@ func (c *cache) ItemCount() int {
 }
 
 // Delete all items from the cache.
-func (c *cache) Flush() {
+func (c *cache[T]) Flush() {
 	c.mu.Lock()
-	c.items = map[string]Item{}
+	c.items = map[string]Item[T]{}
 	c.mu.Unlock()
 }
 
@@ -1073,7 +394,7 @@ type janitor struct {
 	stop     chan bool
 }
 
-func (j *janitor) Run(c *cache) {
+func runJanitor[T comparable](j *janitor, c *cache[T]) {
 	ticker := time.NewTicker(j.Interval)
 	for {
 		select {
@@ -1086,53 +407,54 @@ func (j *janitor) Run(c *cache) {
 	}
 }
 
-func stopJanitor(c *Cache) {
+func stopJanitor[T comparable](c *Cache[T]) {
 	c.janitor.stop <- true
 }
 
-func runJanitor(c *cache, ci time.Duration) {
+func startJanitor[T comparable](c *cache[T], ci time.Duration) {
 	j := &janitor{
 		Interval: ci,
 		stop:     make(chan bool),
 	}
 	c.janitor = j
-	go j.Run(c)
+	go runJanitor(j, c)
 }
 
-func newCache(de time.Duration, m map[string]Item) *cache {
+func newCache[T comparable](de time.Duration, m map[string]Item[T]) *cache[T] {
 	if de == 0 {
 		de = -1
 	}
-	c := &cache{
+	c := &cache[T]{
 		defaultExpiration: de,
 		items:             m,
 	}
 	return c
 }
 
-func newCacheWithJanitor(de time.Duration, ci time.Duration, m map[string]Item) *Cache {
+func newCacheWithJanitor[T comparable](de time.Duration, ci time.Duration, m map[string]Item[T]) *Cache[T] {
 	c := newCache(de, m)
 	// This trick ensures that the janitor goroutine (which--granted it
 	// was enabled--is running DeleteExpired on c forever) does not keep
 	// the returned C object from being garbage collected. When it is
 	// garbage collected, the finalizer stops the janitor goroutine, after
 	// which c can be collected.
-	C := &Cache{c}
+	C := &Cache[T]{c}
 	if ci > 0 {
-		runJanitor(c, ci)
-		runtime.SetFinalizer(C, stopJanitor)
+		startJanitor(c, ci)
+		runtime.SetFinalizer(C, stopJanitor[T])
 	}
 	return C
 }
+
 
 // Return a new cache with a given default expiration duration and cleanup
 // interval. If the expiration duration is less than one (or NoExpiration),
 // the items in the cache never expire (by default), and must be deleted
 // manually. If the cleanup interval is less than one, expired items are not
 // deleted from the cache before calling c.DeleteExpired().
-func New(defaultExpiration, cleanupInterval time.Duration) *Cache {
-	items := make(map[string]Item)
-	return newCacheWithJanitor(defaultExpiration, cleanupInterval, items)
+func New[T comparable](defaultExpiration, cleanupInterval time.Duration) *Cache[T] {
+	items := make(map[string]Item[T])
+	return newCacheWithJanitor[T](defaultExpiration, cleanupInterval, items)
 }
 
 // Return a new cache with a given default expiration duration and cleanup
@@ -1156,6 +478,6 @@ func New(defaultExpiration, cleanupInterval time.Duration) *Cache {
 // gob.Register() the individual types stored in the cache before encoding a
 // map retrieved with c.Items(), and to register those same types before
 // decoding a blob containing an items map.
-func NewFrom(defaultExpiration, cleanupInterval time.Duration, items map[string]Item) *Cache {
+func NewFrom[T comparable](defaultExpiration, cleanupInterval time.Duration, items map[string]Item[T]) *Cache[T] {
 	return newCacheWithJanitor(defaultExpiration, cleanupInterval, items)
 }

--- a/cache_test.go
+++ b/cache_test.go
@@ -1,13 +1,13 @@
 package cache
 
 import (
-	"bytes"
-	"io/ioutil"
-	"runtime"
-	"strconv"
-	"sync"
+	//"bytes"
+	//"io/ioutil"
+	//"runtime"
+	//"strconv"
+	//"sync"
 	"testing"
-	"time"
+	//"time"
 )
 
 type TestStruct struct {
@@ -16,58 +16,61 @@ type TestStruct struct {
 }
 
 func TestCache(t *testing.T) {
-	tc := New(DefaultExpiration, 0)
 
-	a, found := tc.Get("a")
-	if found || a != nil {
+	tcInt := New[int](DefaultExpiration, 0)
+	tcString := New[string](DefaultExpiration, 0)
+	tcFloat := New[float64](DefaultExpiration, 0)
+
+	a, found := tcInt.Get("a")
+	if found || a != 0 {
 		t.Error("Getting A found value that shouldn't exist:", a)
 	}
 
-	b, found := tc.Get("b")
-	if found || b != nil {
+	b, found := tcString.Get("b")
+	if found || b != "" {
 		t.Error("Getting B found value that shouldn't exist:", b)
 	}
 
-	c, found := tc.Get("c")
-	if found || c != nil {
+	c, found := tcFloat.Get("c")
+	if found || c != 0.0 {
 		t.Error("Getting C found value that shouldn't exist:", c)
 	}
 
-	tc.Set("a", 1, DefaultExpiration)
-	tc.Set("b", "b", DefaultExpiration)
-	tc.Set("c", 3.5, DefaultExpiration)
+	tcInt.Set("a", 1, DefaultExpiration)
+	tcString.Set("b", "b", DefaultExpiration)
+	tcFloat.Set("c", 3.5, DefaultExpiration)
 
-	x, found := tc.Get("a")
+	a2, found := tcInt.Get("a")
 	if !found {
 		t.Error("a was not found while getting a2")
 	}
-	if x == nil {
-		t.Error("x for a is nil")
-	} else if a2 := x.(int); a2+2 != 3 {
+	if a2 == 0 {
+		t.Error("x for a is 0 (zero value)")
+	} else if a2+2 != 3 {
 		t.Error("a2 (which should be 1) plus 2 does not equal 3; value:", a2)
 	}
 
-	x, found = tc.Get("b")
+	b2, found := tcString.Get("b")
 	if !found {
 		t.Error("b was not found while getting b2")
 	}
-	if x == nil {
-		t.Error("x for b is nil")
-	} else if b2 := x.(string); b2+"B" != "bB" {
+	if b2 == "" {
+		t.Error("x for b is \"\" (zero value)")
+	} else if b2+"B" != "bB" {
 		t.Error("b2 (which should be b) plus B does not equal bB; value:", b2)
 	}
 
-	x, found = tc.Get("c")
+	c2, found := tcFloat.Get("c")
 	if !found {
 		t.Error("c was not found while getting c2")
 	}
-	if x == nil {
-		t.Error("x for c is nil")
-	} else if c2 := x.(float64); c2+1.2 != 4.7 {
+	if c2 == 0.0 {
+		t.Error("x for c is 0.0 (zero value)")
+	} else if c2+1.2 != 4.7 {
 		t.Error("c2 (which should be 3.5) plus 1.2 does not equal 4.7; value:", c2)
 	}
 }
-
+/*
 func TestCacheTimes(t *testing.T) {
 	var found bool
 
@@ -1769,3 +1772,5 @@ func TestGetWithExpiration(t *testing.T) {
 		t.Error("expiration for e is in the past")
 	}
 }
+
+*/

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/patrickmn/go-cache
+
+go 1.18

--- a/sharded.go
+++ b/sharded.go
@@ -1,5 +1,6 @@
 package cache
 
+/*
 import (
 	"crypto/rand"
 	"math"
@@ -190,3 +191,4 @@ func unexportedNewSharded(defaultExpiration, cleanupInterval time.Duration, shar
 	}
 	return SC
 }
+*/

--- a/sharded_test.go
+++ b/sharded_test.go
@@ -1,5 +1,6 @@
 package cache
 
+/*
 import (
 	"strconv"
 	"sync"
@@ -83,3 +84,4 @@ func benchmarkShardedCacheGetManyConcurrent(b *testing.B, exp time.Duration) {
 	b.StartTimer()
 	wg.Wait()
 }
+*/


### PR DESCRIPTION
Replaces #128 

Makes the cache generically typed using (as of yet not released) [go generics](https://go.dev/blog/generics-proposal), so clients code looks like:
```
    c := cache.New[int](cache.DefaultExpiration, 0)
    c.Set("foo", 5, cache.DefaultExpiration)
    c.Increment("foo", 1)
    value, _ := c.Get("foo")
    fmt.Printf("5+1=%d\n", value+1)
```


Some open issues/questions:
1. Not finished (need to implement remainder of cache_test and all of sharded)
1. Current implementation is *NOT* backwards compatible (type inference doesn't work in general and client code must say e.g. `cache.New[int](...)` )
   a. TODO: Is this possible to fix?
1. This code won't compile without generics, so to test you'll need to have a local copy of go1.18 (https://go.dev/doc/tutorial/generics#installing_beta)
   ```
   luke@LMASSA-MAC go-cache % go test ./...
   # github.com/patrickmn/go-cache [github.com/patrickmn/go-cache.test]
   ./cache.go:13:14: syntax error: unexpected comparable, expecting ]
   ./cache.go:19:16: syntax error: unexpected [, expecting comma or )
   ./cache.go:35:15: syntax error: unexpected comparable, expecting ]
   ./cache.go:42:15: syntax error: unexpected comparable, expecting ]
   ./cache.go:46:35: method has multiple receivers
   ./cache.go:46:35: syntax error: unexpected newline, expecting name or (
   ./cache.go:47:2: syntax error: non-declaration statement outside function body
   luke@LMASSA-MAC go-cache % ~/go/bin/go1.18beta1 test ./...
   ok  	github.com/patrickmn/go-cache	0.549s
   ```
1. Is it possible to reduce duplication of `comparable` for non-method functions?
1. It didn't feel right to make `janitor` dependent on type, but that meant converting Run() from a method to a function (https://go.googlesource.com/proposal/+/refs/heads/master/design/43651-type-parameters.md#No-parameterized-methods)
1. I removed all the `Increment*` and `Decrement*` methods since the `Increment()` and `Decrement()` methods themselves return the correct concrete type
1. On that note, Increment and Decrement are not type-safe, which replicates the behavior of the current implementation. Some ideas there:
   a. Leave as is (no worse than non-generic)
   b. Have an "IncrementableCache" type that takes a generic typeset that would allow us to use "+"