### PR TITLE
Call onEvicted on flush

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -1064,7 +1064,12 @@ func (c *cache) ItemCount() int {
 // Delete all items from the cache.
 func (c *cache) Flush() {
 	c.mu.Lock()
-	c.items = map[string]Item{}
+	for k := range c.items {
+		v, evicted := c.delete(k)
+		if evicted {
+			c.onEvicted(k, v)
+		}
+	}
 	c.mu.Unlock()
 }
 


### PR DESCRIPTION
The documentation of `Flush` states, that it deletes all items from the cache. When calling `Delete`, `onEvicted` is run. Combining these two pieces of knowledge I expected, that `onEvicted` would be called for all items, when calling `Flush`, but I had to learn, that this assumption is incorrect.

Was this a deliberate design decision, or would you consider changing the behavior?